### PR TITLE
Message passing refinements

### DIFF
--- a/python/vegafusion-jupyter/vegafusion_jupyter/widget.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/widget.py
@@ -113,7 +113,8 @@ class VegaFusionWidget(DOMWidget):
                 msg_bytes
             )
 
+            message_len = len(response_bytes)
             self._response_msg = response_bytes
 
             duration = (time.time() - start) * 1000
-            self._log(f"Sent response in {duration:.1f}ms")
+            self._log(f"Sent response in {duration:.1f}ms ({message_len} bytes)")

--- a/python/vegafusion-jupyter/vegafusion_jupyter/widget.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/widget.py
@@ -114,7 +114,6 @@ class VegaFusionWidget(DOMWidget):
             )
 
             self._response_msg = response_bytes
-            self._response_msg = None
 
             duration = (time.time() - start) * 1000
             self._log(f"Sent response in {duration:.1f}ms")

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -291,16 +291,18 @@ impl MsgReceiver {
                             .filter(|node| server_to_client.contains(node))
                             .collect();
 
-                        let request_msg = QueryRequest {
-                            request: Some(query_request::Request::TaskGraphValues(
-                                TaskGraphValueRequest {
-                                    task_graph: Some(task_graph.clone()),
-                                    indices: updated_nodes,
-                                },
-                            )),
-                        };
+                        if !updated_nodes.is_empty() {
+                            let request_msg = QueryRequest {
+                                request: Some(query_request::Request::TaskGraphValues(
+                                    TaskGraphValueRequest {
+                                        task_graph: Some(task_graph.clone()),
+                                        indices: updated_nodes,
+                                    },
+                                )),
+                            };
 
-                        this.send_request(send_msg_fn.as_ref(), request_msg);
+                            this.send_request(send_msg_fn.as_ref(), request_msg);
+                        }
                     })
                         as Box<dyn FnMut(String, JsValue)>);
 


### PR DESCRIPTION
Two small updates to how messages are exchanged between client and server:
 1. Client should not send a task graph query to the server if no nodes need updating (if the request indices is empty)
 2. The server (vegafusion-jupyter in this case) shouldn't manually clear the message prop after sending a response. This was causing dropped messages in certain situations. 