### PR TITLE
Add timeFormat and utcFormat expression function

### DIFF
--- a/vegafusion-core/src/expression/supported.rs
+++ b/vegafusion-core/src/expression/supported.rs
@@ -59,7 +59,7 @@ lazy_static! {
         // Datetime
         "year", "quarter", "month", "day", "date", "dayofyear", "hours", "minutes", "seconds",
         "utcyear", "utcquarter", "utcmonth", "utcday", "utcdate", "utcdayofyear",
-        "utchours", "utcminutes", "utcseconds", "datetime", "utc", "time",
+        "utchours", "utcminutes", "utcseconds", "datetime", "utc", "time", "timeFormat", "utcFormat",
 
         // Conversion
         "toBoolean", "toDate", "toNumber", "toString",

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_format.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_format.rs
@@ -1,0 +1,128 @@
+/*
+ * VegaFusion
+ * Copyright (C) 2022 VegaFusion Technologies LLC
+ *
+ * This program is distributed under multiple licenses.
+ * Please consult the license documentation provided alongside
+ * this program the details of the active license.
+ */
+use crate::expression::compiler::builtin_functions::date_time::process_input_datetime;
+use chrono::TimeZone;
+use chrono::{DateTime, NaiveDateTime};
+use datafusion::arrow::array::{ArrayRef, Date32Array, Int64Array, StringArray};
+use datafusion::arrow::compute::cast;
+use datafusion::arrow::datatypes::{DataType, TimeUnit};
+use datafusion::logical_plan::{DFSchema, Expr};
+use datafusion::physical_plan::functions::{make_scalar_function, Signature, Volatility};
+use datafusion::physical_plan::udf::ScalarUDF;
+use datafusion::scalar::ScalarValue;
+use datafusion_expr::ReturnTypeFunction;
+use std::sync::Arc;
+use vegafusion_core::arrow::compute::unary;
+use vegafusion_core::error::{Result, ResultWithContext, VegaFusionError};
+
+pub fn time_format_fn(local_tz: chrono_tz::Tz, args: &[Expr], schema: &DFSchema) -> Result<Expr> {
+    let format_str = extract_format_str(&args)?;
+    Ok(Expr::ScalarUDF {
+        fun: Arc::new(make_time_format_udf(&local_tz, &local_tz, &format_str)),
+        args: Vec::from(&args[..1]),
+    })
+}
+
+pub fn utc_format_fn(local_tz: chrono_tz::Tz, args: &[Expr], schema: &DFSchema) -> Result<Expr> {
+    let format_str = extract_format_str(&args)?;
+    Ok(Expr::ScalarUDF {
+        fun: Arc::new(make_time_format_udf(
+            &local_tz,
+            &chrono_tz::UTC,
+            &format_str,
+        )),
+        args: Vec::from(&args[..1]),
+    })
+}
+
+pub fn extract_format_str(args: &[Expr]) -> Result<String> {
+    let format_str = if args.len() >= 2 {
+        let format_arg = &args[1];
+        match format_arg {
+            Expr::Literal(ScalarValue::Utf8(Some(format_str))) => Ok(format_str.clone()),
+            _ => {
+                return Err(VegaFusionError::compilation(
+                    "the second argument to the timeFormat function must be a literal string",
+                ))
+            }
+        }
+    } else if args.len() == 1 {
+        Ok("%I:%M".to_string())
+    } else {
+        Err(VegaFusionError::compilation(
+            "the timeFormat function must have at least one argument",
+        ))
+    }?;
+
+    // Add compatibility adjustments from D3 to Chrono
+
+    // %f is microseconds in D3 but nanoseconds, this is %6f is chrono
+    let format_str = format_str.replace("%f", "%6f");
+
+    // %L is milliseconds in D3, this is %f3f in chrono
+    let format_str = format_str.replace("%L", "%3f");
+    Ok(format_str)
+}
+
+pub fn make_time_format_udf(
+    local_tz: &chrono_tz::Tz,
+    format_tz: &chrono_tz::Tz,
+    format_str: &str,
+) -> ScalarUDF {
+    let local_tz = local_tz.clone();
+    let format_tz = format_tz.clone();
+    let format_str = format_str.to_string();
+    let time_fn = move |args: &[ArrayRef]| {
+        // Signature ensures there is a single argument
+        let arg = &args[0];
+        let arg = process_input_datetime(arg, &local_tz);
+
+        let utc_millis_array = arg.as_any().downcast_ref::<Int64Array>().unwrap();
+
+        let formatted = StringArray::from_iter(utc_millis_array.iter().map(|utc_millis| {
+            utc_millis.map(|utc_millis| {
+                // Load as UTC datetime
+                let utc_seconds = utc_millis / 1_000;
+                let utc_nanos = (utc_millis % 1_000 * 1_000_000) as u32;
+                let naive_utc_datetime = NaiveDateTime::from_timestamp(utc_seconds, utc_nanos);
+
+                // Convert to local timezone
+                let datetime: DateTime<chrono_tz::Tz> =
+                    format_tz.from_utc_datetime(&naive_utc_datetime);
+
+                // Format as string
+                let formatted = datetime.format(&format_str);
+                formatted.to_string()
+            })
+        }));
+
+        Ok(Arc::new(formatted) as ArrayRef)
+    };
+    let time_fn = make_scalar_function(time_fn);
+
+    let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Int64)));
+
+    ScalarUDF::new(
+        "timeFormat",
+        &Signature::uniform(
+            1,
+            vec![
+                DataType::Utf8,
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                DataType::Date32,
+                DataType::Date64,
+                DataType::Int64,
+                DataType::Float64,
+            ],
+            Volatility::Immutable,
+        ),
+        &return_type,
+        &time_fn,
+    )
+}

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_parts.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_parts.rs
@@ -116,7 +116,7 @@ pub fn make_datepart_udf(
                 let utc_seconds = utc_millis / 1_000;
                 let utc_nanos = (utc_millis % 1_000 * 1_000_000) as u32;
                 let naive_utc_datetime = NaiveDateTime::from_timestamp(utc_seconds, utc_nanos);
-                let datetime = tz.from_utc_datetime(&naive_utc_datetime);
+                let datetime: DateTime<chrono_tz::Tz> = tz.from_utc_datetime(&naive_utc_datetime);
                 let value = extract_fn(&datetime);
                 result_builder.append_value(value).unwrap();
             }

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_parts.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_parts.rs
@@ -6,22 +6,17 @@
  * Please consult the license documentation provided alongside
  * this program the details of the active license.
  */
-use crate::expression::compiler::builtin_functions::date_time::date_parsing::{
-    datetime_strs_to_millis, DateParseMode,
-};
 
 use crate::expression::compiler::builtin_functions::date_time::process_input_datetime;
 use crate::expression::compiler::call::LocalTransformFn;
 use chrono::{DateTime, Datelike, NaiveDateTime, TimeZone, Timelike, Weekday};
-use datafusion::arrow::array::{Array, ArrayRef, Date32Array, Int64Array, StringArray};
-use datafusion::arrow::compute::cast;
+use datafusion::arrow::array::{Array, ArrayRef, Int64Array};
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::logical_plan::{DFSchema, Expr};
 use datafusion::physical_plan::functions::{make_scalar_function, Signature, Volatility};
 use datafusion::physical_plan::udf::ScalarUDF;
 use datafusion_expr::ReturnTypeFunction;
 use std::sync::Arc;
-use vegafusion_core::arrow::compute::unary;
 use vegafusion_core::error::Result;
 
 #[inline(always)]

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/mod.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/mod.rs
@@ -17,3 +17,37 @@ pub mod date_parts;
 pub mod datetime;
 pub mod local_to_utc;
 pub mod time;
+
+use crate::expression::compiler::builtin_functions::date_time::date_parsing::{
+    datetime_strs_to_millis, DateParseMode,
+};
+use datafusion::arrow::array::{ArrayRef, Date32Array, Int64Array, StringArray};
+use datafusion::arrow::compute::{cast, unary};
+use datafusion::arrow::datatypes::{DataType, TimeUnit};
+use std::sync::Arc;
+
+fn process_input_datetime(arg: &ArrayRef, tz: &chrono_tz::Tz) -> ArrayRef {
+    match arg.data_type() {
+        DataType::Utf8 => {
+            let array = arg.as_any().downcast_ref::<StringArray>().unwrap();
+            datetime_strs_to_millis(array, DateParseMode::JavaScript, &Some(*tz)) as _
+        }
+        DataType::Timestamp(TimeUnit::Millisecond, _) => {
+            cast(arg, &DataType::Int64).expect("Failed to case timestamp to Int64")
+        }
+        DataType::Date32 => {
+            let ms_per_day = 1000 * 60 * 60 * 24_i64;
+            let array = arg.as_any().downcast_ref::<Date32Array>().unwrap();
+
+            let array: Int64Array = unary(array, |v| (v as i64) * ms_per_day);
+            Arc::new(array) as ArrayRef as _
+        }
+        DataType::Date64 => {
+            let int_array = cast(arg, &DataType::Int64).unwrap();
+            int_array
+        }
+        DataType::Int64 => arg.clone(),
+        DataType::Float64 => cast(arg, &DataType::Int64).expect("Failed to case float to int"),
+        _ => panic!("Unexpected data type for date part function:"),
+    }
+}

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/mod.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/mod.rs
@@ -12,6 +12,7 @@ Functions for working with date-time values.
 
 See: https://vega.github.io/vega/docs/expressions/#datetime-functions
 */
+pub mod date_format;
 pub mod date_parsing;
 pub mod date_parts;
 pub mod datetime;

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/time.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/time.rs
@@ -7,18 +7,16 @@
  * this program the details of the active license.
  */
 use crate::expression::compiler::builtin_functions::date_time::process_input_datetime;
-use datafusion::arrow::array::{ArrayRef, Date32Array, Int64Array};
-use datafusion::arrow::compute::cast;
+use datafusion::arrow::array::ArrayRef;
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::logical_plan::{DFSchema, Expr};
 use datafusion::physical_plan::functions::{make_scalar_function, Signature, Volatility};
 use datafusion::physical_plan::udf::ScalarUDF;
 use datafusion_expr::ReturnTypeFunction;
 use std::sync::Arc;
-use vegafusion_core::arrow::compute::unary;
-use vegafusion_core::error::{Result, ResultWithContext};
+use vegafusion_core::error::Result;
 
-pub fn time_fn(local_tz: chrono_tz::Tz, args: &[Expr], schema: &DFSchema) -> Result<Expr> {
+pub fn time_fn(local_tz: chrono_tz::Tz, args: &[Expr], _schema: &DFSchema) -> Result<Expr> {
     Ok(Expr::ScalarUDF {
         fun: Arc::new(make_time_udf(local_tz)),
         args: Vec::from(args),

--- a/vegafusion-rt-datafusion/src/expression/compiler/call.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/call.rs
@@ -45,7 +45,7 @@ use crate::expression::compiler::builtin_functions::data::vl_selection_test::vl_
 use crate::expression::compiler::builtin_functions::date_time::date_format::{
     time_format_fn, utc_format_fn,
 };
-use crate::expression::compiler::builtin_functions::date_time::time::{make_time_udf, time_fn};
+use crate::expression::compiler::builtin_functions::date_time::time::time_fn;
 use crate::expression::compiler::builtin_functions::type_checking::isdate::is_date_fn;
 use crate::expression::compiler::builtin_functions::type_coercion::to_boolean::to_boolean_transform;
 use crate::expression::compiler::builtin_functions::type_coercion::to_number::to_number_transform;

--- a/vegafusion-rt-datafusion/src/expression/compiler/call.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/call.rs
@@ -42,6 +42,9 @@ use vegafusion_core::proto::gen::expression::{
 use crate::expression::compiler::builtin_functions::data::data_fn::data_fn;
 use crate::expression::compiler::builtin_functions::data::vl_selection_resolve::vl_selection_resolve_fn;
 use crate::expression::compiler::builtin_functions::data::vl_selection_test::vl_selection_test_fn;
+use crate::expression::compiler::builtin_functions::date_time::date_format::{
+    time_format_fn, utc_format_fn,
+};
 use crate::expression::compiler::builtin_functions::date_time::time::{make_time_udf, time_fn};
 use crate::expression::compiler::builtin_functions::type_checking::isdate::is_date_fn;
 use crate::expression::compiler::builtin_functions::type_coercion::to_boolean::to_boolean_transform;
@@ -399,6 +402,14 @@ pub fn default_callables() -> HashMap<String, VegaFusionCallable> {
     callables.insert(
         "time".to_string(),
         VegaFusionCallable::LocalTransform(Arc::new(time_fn)),
+    );
+    callables.insert(
+        "timeFormat".to_string(),
+        VegaFusionCallable::LocalTransform(Arc::new(time_format_fn)),
+    );
+    callables.insert(
+        "utcFormat".to_string(),
+        VegaFusionCallable::LocalTransform(Arc::new(utc_format_fn)),
     );
 
     // coercion

--- a/vegafusion-rt-datafusion/src/expression/compiler/call.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/call.rs
@@ -42,7 +42,7 @@ use vegafusion_core::proto::gen::expression::{
 use crate::expression::compiler::builtin_functions::data::data_fn::data_fn;
 use crate::expression::compiler::builtin_functions::data::vl_selection_resolve::vl_selection_resolve_fn;
 use crate::expression::compiler::builtin_functions::data::vl_selection_test::vl_selection_test_fn;
-use crate::expression::compiler::builtin_functions::date_time::time::make_time_udf;
+use crate::expression::compiler::builtin_functions::date_time::time::{make_time_udf, time_fn};
 use crate::expression::compiler::builtin_functions::type_checking::isdate::is_date_fn;
 use crate::expression::compiler::builtin_functions::type_coercion::to_boolean::to_boolean_transform;
 use crate::expression::compiler::builtin_functions::type_coercion::to_number::to_number_transform;
@@ -398,10 +398,7 @@ pub fn default_callables() -> HashMap<String, VegaFusionCallable> {
     );
     callables.insert(
         "time".to_string(),
-        VegaFusionCallable::ScalarUDF {
-            udf: make_time_udf(),
-            cast: None,
-        },
+        VegaFusionCallable::LocalTransform(Arc::new(time_fn)),
     );
 
     // coercion

--- a/vegafusion-rt-datafusion/tests/test_expression_evaluation.rs
+++ b/vegafusion-rt-datafusion/tests/test_expression_evaluation.rs
@@ -353,6 +353,30 @@ mod test_time {
     fn test_marker() {} // Help IDE detect test module
 }
 
+mod test_time_and_utc_format {
+    use crate::*;
+
+    #[rstest(
+        expr,
+        case("timeFormat(toDate('2020-05-16T09:30:00+05:00'), '%Y-%m-%d %H:%M:%S')"),
+        case("utcFormat(toDate('2020-05-16T09:30:00+05:00'), '%Y-%m-%d %H:%M:%S')"),
+        case("timeFormat(toDate('2020-05-16 09:30:00+05:00'))"),
+        case("utcFormat(toDate('2020-05-16 09:30:00+05:00'))"),
+        case("timeFormat(1589603400000, '%Y-%m-%d %p %s')"),
+        case("utcFormat(1589603400000, '%Y-%m-%d %G %g')"),
+        case("timeFormat(datetime(87, 3, 10, 7, 35, 10, 87), '%a %A %b %B %d %e %g')"),
+        case("utcFormat(datetime(87, 3, 10, 7, 35, 10, 87), '%a %A %b %B %d %e %g')"),
+        case("timeFormat(datetime(87, 3, 10, 7, 35, 10, 87), '%Y-%m-%d %H:%M:%S.%L')"),
+        case("utcFormat(datetime(87, 3, 10, 7, 35, 10, 87), '%Y-%m-%d %H:%M:%S.%f')")
+    )]
+    fn test(expr: &str) {
+        check_scalar_evaluation(expr, &config_a())
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
+}
+
 mod test_date_parts {
     #[rstest(
         expr,

--- a/vegafusion-rt-datafusion/tests/test_expression_evaluation.rs
+++ b/vegafusion-rt-datafusion/tests/test_expression_evaluation.rs
@@ -311,6 +311,48 @@ mod test_datetime {
     fn test_marker() {} // Help IDE detect test module
 }
 
+mod test_time {
+    use crate::*;
+
+    #[rstest(
+        expr,
+        case("time('2020-05-16T09:30:00+05:00')"),
+        case("time('2020-05-16 09:30:00+05:00')"),
+        case("time('2020-05-16 09:30:00-07:00')"),
+        case("time('2020-05-16 09:30:00Z')"),
+        case("time('2020-05-16 09:30:00')"),
+        case("time('2020/05/16 09:30')"),
+        case("time('05/16/2020 09:30')"),
+        case("time('May 16 2020 09:30')"),
+        case("time('2020 May 16  09:30')"),
+        case("time('2020-01-01 00:00')"),
+        case("time('2020-01-01')"),
+        case("time('2020/01/01')"),
+        case("time('01/01/2020')"),
+        case("time(1589603400000)"),
+        case("time(datetime(87, 3, 10, 7, 35, 10, 87))"),
+        case("time(datetime(87, 3, 10, 7, 35, 10))"),
+        case("time(datetime(87, 3, 10, 7, 35))"),
+        case("time(datetime(87, 3, 10, 7))"),
+        case("time(datetime(87, 3, 10))"),
+        case("time(datetime(87, 3))"),
+        case("time(datetime(utc(87, 3, 10, 7, 35, 10, 87)))"),
+        case("time(datetime(utc(87, 3, 10, 7, 35, 10)))"),
+        case("time(datetime(utc(87, 3, 10, 7, 35)))"),
+        case("time(datetime(utc(87, 3, 10, 7)))"),
+        case("time(datetime(utc(87, 3, 10)))"),
+        case("time(datetime(utc(87, 3)))"),
+        case("time(\"2000-01-01T08:00:00.000Z\")"),
+        case("time(\"2000-01-01T13:14:15.123Z\")")
+    )]
+    fn test(expr: &str) {
+        check_scalar_evaluation(expr, &config_a())
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
+}
+
 mod test_date_parts {
     #[rstest(
         expr,


### PR DESCRIPTION
This PR adds support for the [`timeFormat`](https://vega.github.io/vega/docs/expressions/#timeFormat) and [`utcFormat`](https://vega.github.io/vega/docs/expressions/#utcFormat) Vega expression functions.

This is part of the proposal in https://github.com/vegafusion/vegafusion/issues/104 as VegaFusion will be required to produce string representations of datetimes in certain situations.