### PR TITLE
Avoid serialization of pyarrow tables using PyArrowConvert in pre_transform_spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "lexical-core",
  "multiversion",
  "num",
+ "pyo3",
  "rand",
  "regex",
  "serde",
@@ -629,6 +630,7 @@ dependencies = [
  "arrow",
  "ordered-float 3.0.0",
  "parquet",
+ "pyo3",
  "sqlparser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "load_image"
 version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1487,15 @@ name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f64ad83c969af2e732e907564deb0d0ed393cec4af80776f77dd77a1a427698"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -3061,6 +3079,7 @@ dependencies = [
 name = "vegafusion-python-embed"
 version = "0.4.0"
 dependencies = [
+ "mimalloc",
  "pyo3",
  "serde",
  "serde_json",

--- a/python/vegafusion-jupyter/package-lock.json
+++ b/python/vegafusion-jupyter/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-jupyter",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@jupyter-widgets/base": "^1.1.10 || ^2.0.0 || ^3.0.0 || ^4.0.0",
@@ -50,7 +50,7 @@
       }
     },
     "../../javascript/vegafusion-embed": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -9715,7 +9715,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -11553,7 +11553,7 @@
         "node": ">=12"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -18457,7 +18457,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -18475,7 +18475,7 @@
         "lib0": "^0.2.31"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -18490,7 +18490,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -18508,7 +18508,7 @@
         "y-websocket-server": "bin/server.js"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "optionalDependencies": {
@@ -18591,7 +18591,7 @@
         "lib0": "^0.2.49"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },

--- a/python/vegafusion-jupyter/vegafusion_jupyter/nbextension/extension.js
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/nbextension/extension.js
@@ -1,6 +1,6 @@
 /*
  * VegaFusion
- * Copyright (C) 2022 Jon Mease
+ * Copyright (C) 2022 VegaFusion Technologies LLC
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -6,6 +6,7 @@ license = "AGPL-3.0-or-later"
 
 [features]
 tonic_support = [ "tonic", "tonic-build",]
+pyarrow = ["pyo3", "arrow/pyarrow", "datafusion-common/pyarrow"]
 
 [dependencies]
 thiserror = "^1.0.29"

--- a/vegafusion-core/src/data/table.rs
+++ b/vegafusion-core/src/data/table.rs
@@ -211,6 +211,7 @@ impl From<RecordBatch> for VegaFusionTable {
     }
 }
 
+
 impl Hash for VegaFusionTable {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.to_ipc_bytes().unwrap().hash(state)

--- a/vegafusion-core/src/data/table.rs
+++ b/vegafusion-core/src/data/table.rs
@@ -211,7 +211,6 @@ impl From<RecordBatch> for VegaFusionTable {
     }
 }
 
-
 impl Hash for VegaFusionTable {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.to_ipc_bytes().unwrap().hash(state)

--- a/vegafusion-python-embed/Cargo.toml
+++ b/vegafusion-python-embed/Cargo.toml
@@ -30,3 +30,7 @@ features = [ "macros", "rt-multi-thread",]
 [dependencies.pyo3]
 version = "0.16.4"
 features = [ "extension-module",]
+
+[dependencies.mimalloc]
+version = "*"
+default-features = false

--- a/vegafusion-python-embed/Cargo.toml
+++ b/vegafusion-python-embed/Cargo.toml
@@ -21,6 +21,7 @@ features = [ "pyo3",]
 
 [dependencies.vegafusion-rt-datafusion]
 path = "../vegafusion-rt-datafusion"
+features = ["pyarrow"]
 
 [dependencies.tokio]
 version = "1.18.1"

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -23,6 +23,11 @@ use vegafusion_core::arrow::pyarrow::PyArrowConvert;
 use vegafusion_core::arrow::record_batch::RecordBatch;
 use vegafusion_core::data::table::VegaFusionTable;
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 #[derive(Clone, Serialize, Deserialize)]
 struct PreTransformWarning {
     #[serde(rename = "type")]

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -90,11 +90,11 @@ impl PyTaskGraphRuntime {
                 let list = tuple.get_item(1)?.cast_as::<PyList>()?;
                 let batches: Vec<_> = list
                     .iter()
-                    .map(|item| RecordBatch::from_pyarrow(item))
+                    .map(RecordBatch::from_pyarrow)
                     .collect::<PyResult<Vec<_>>>()?;
                 Ok((
                     name.to_string(),
-                    VegaFusionTable::try_new(Arc::new(schema.clone()), batches.clone())?,
+                    VegaFusionTable::try_new(Arc::new(schema), batches)?,
                 ))
             })
             .collect::<PyResult<HashMap<_, _>>>()?;

--- a/vegafusion-rt-datafusion/Cargo.toml
+++ b/vegafusion-rt-datafusion/Cargo.toml
@@ -8,6 +8,9 @@ version = "0.4.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 
+[features]
+pyarrow = ["vegafusion-core/pyarrow"]
+
 [dependencies]
 regex = "^1.5.5"
 lazy_static = "^1.4.0"


### PR DESCRIPTION
## Overview

This PR updates the `pre_transform_spec` functionality to avoid copying/serializing PyArrow tables by using the `PyArrowConvert` functions from the `arrow-rs` crate.

This PR also follows the `datafusion-python` project by enabling the [`mimalloc`](https://github.com/microsoft/mimalloc) global allocator (https://github.com/datafusion-contrib/datafusion-python/pull/30) in the `vegafusion-python-embed` library.