### PR TITLE
Add additional test mocks

### DIFF
--- a/vegafusion-core/src/expression/escape.rs
+++ b/vegafusion-core/src/expression/escape.rs
@@ -1,14 +1,14 @@
 pub fn escape_field(col: &str) -> String {
     // Escape single quote with backslash
-    let col = col.replace("'", "\\'");
+    let col = col.replace('\'', "\\'");
 
     // Escape double quote with backslash
-    let col = col.replace("\"", "\\\"");
+    let col = col.replace('\"', "\\\"");
 
     // Escape period with backslash
-    let col = col.replace(".", "\\.");
+    
 
-    col
+    col.replace('.', "\\.")
 }
 
 pub fn unescape_field(col: &str) -> String {
@@ -19,9 +19,9 @@ pub fn unescape_field(col: &str) -> String {
     let col = col.replace("\\\"", "\"");
 
     //  Unescape backslash period
-    let col = col.replace("\\.", ".");
+    
 
-    col
+    col.replace("\\.", ".")
 }
 
 #[cfg(test)]

--- a/vegafusion-core/src/expression/escape.rs
+++ b/vegafusion-core/src/expression/escape.rs
@@ -6,7 +6,6 @@ pub fn escape_field(col: &str) -> String {
     let col = col.replace('\"', "\\\"");
 
     // Escape period with backslash
-    
 
     col.replace('.', "\\.")
 }
@@ -19,7 +18,6 @@ pub fn unescape_field(col: &str) -> String {
     let col = col.replace("\\\"", "\"");
 
     //  Unescape backslash period
-    
 
     col.replace("\\.", ".")
 }

--- a/vegafusion-core/src/expression/escape.rs
+++ b/vegafusion-core/src/expression/escape.rs
@@ -1,0 +1,44 @@
+pub fn escape_field(col: &str) -> String {
+    // Escape single quote with backslash
+    let col = col.replace("'", "\\'");
+
+    // Escape double quote with backslash
+    let col = col.replace("\"", "\\\"");
+
+    // Escape period with backslash
+    let col = col.replace(".", "\\.");
+
+    col
+}
+
+pub fn unescape_field(col: &str) -> String {
+    // Unescape backslash single quote
+    let col = col.replace("\\'", "'");
+
+    // Unescape backslash double quote
+    let col = col.replace("\\\"", "\"");
+
+    //  Unescape backslash period
+    let col = col.replace("\\.", ".");
+
+    col
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::expression::escape::{escape_field, unescape_field};
+
+    #[test]
+    fn test_escape() {
+        let col = "'foo'_._\"bar\"";
+        let escaped = escape_field(col);
+        assert_eq!(escaped, r#"\'foo\'_\._\"bar\""#)
+    }
+
+    #[test]
+    fn test_unescape() {
+        let col = r#"\'foo\'_\._\"bar\""#;
+        let unescaped = unescape_field(col);
+        assert_eq!(unescaped, "'foo'_._\"bar\"")
+    }
+}

--- a/vegafusion-core/src/expression/mod.rs
+++ b/vegafusion-core/src/expression/mod.rs
@@ -8,6 +8,7 @@
  */
 pub mod ast;
 pub mod column_usage;
+pub mod escape;
 pub mod lexer;
 pub mod ops;
 pub mod parser;

--- a/vegafusion-core/src/planning/projection_pushdown.rs
+++ b/vegafusion-core/src/planning/projection_pushdown.rs
@@ -328,7 +328,7 @@ impl GetDatasetsColumnUsage for ScaleDataReferenceSpec {
                 if let Some(sort_field) = &sort_params.field {
                     usage = usage.with_column_usage(
                         &scoped_datum_var,
-                        ColumnUsage::from(unescape_field(&sort_field).as_str()),
+                        ColumnUsage::from(unescape_field(sort_field).as_str()),
                     );
                 }
             }

--- a/vegafusion-core/src/planning/split_domain_data.rs
+++ b/vegafusion-core/src/planning/split_domain_data.rs
@@ -8,6 +8,7 @@
  */
 
 use crate::error::Result;
+use crate::expression::escape::escape_field;
 use crate::proto::gen::tasks::Variable;
 use crate::spec::chart::{ChartSpec, MutChartVisitor};
 use crate::spec::data::DataSpec;
@@ -179,8 +180,20 @@ impl<'a> MutChartVisitor for SplitUrlDataNodeVisitor<'a> {
 
                 // Create new domain specification that uses the new dataset
                 let new_domain: ScaleDomainSpec = serde_json::from_value(serde_json::json!([
-                    { "signal": format!("(data('{}')[0] || {{}}).min", new_data_name) },
-                    { "signal": format!("(data('{}')[0] || {{}}).max", new_data_name) }
+                    {
+                        "signal":
+                            format!(
+                                "(data(\"{}\")[0] || {{}}).min",
+                                escape_field(&new_data_name)
+                            )
+                    },
+                    {
+                        "signal":
+                            format!(
+                                "(data(\"{}\")[0] || {{}}).max",
+                                escape_field(&new_data_name)
+                            )
+                    }
                 ]))
                 .unwrap();
 

--- a/vegafusion-core/src/spec/scale.rs
+++ b/vegafusion-core/src/spec/scale.rs
@@ -76,6 +76,8 @@ impl ScaleTypeSpec {
 pub enum ScaleDomainSpec {
     FieldReference(ScaleDataReferenceSpec),
     FieldsReference(ScaleDataReferencesSpec),
+    FieldsVecStrings(ScaleVecStringsSpec),
+    FieldsStrings(ScaleStringsSpec),
     FieldsSignals(ScaleSignalsSpec),
     Signal(SignalExpressionSpec),
     Array(Vec<ScaleArrayElementSpec>),
@@ -101,6 +103,22 @@ pub struct ScaleDataReferenceSpec {
     // Need to support sort objects as well as booleans
     // #[serde(skip_serializing_if = "Option::is_none")]
     // pub sort: Option<bool>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScaleVecStringsSpec {
+    pub fields: Vec<Vec<String>>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScaleStringsSpec {
+    pub fields: Vec<String>,
+
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }

--- a/vegafusion-core/src/spec/scale.rs
+++ b/vegafusion-core/src/spec/scale.rs
@@ -76,6 +76,7 @@ impl ScaleTypeSpec {
 pub enum ScaleDomainSpec {
     FieldReference(ScaleDataReferenceSpec),
     FieldsReference(ScaleDataReferencesSpec),
+    FieldsSignals(ScaleSignalsSpec),
     Signal(SignalExpressionSpec),
     Array(Vec<ScaleArrayElementSpec>),
     Value(Value),
@@ -100,6 +101,14 @@ pub struct ScaleDataReferenceSpec {
     // Need to support sort objects as well as booleans
     // #[serde(skip_serializing_if = "Option::is_none")]
     // pub sort: Option<bool>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScaleSignalsSpec {
+    pub fields: Vec<SignalExpressionSpec>,
+
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -565,6 +565,9 @@ impl<'a> ChartVisitor for InputVarsChartVisitor<'a> {
                 ScaleDomainSpec::FieldsReference(field_references) => {
                     references.extend(field_references.fields.clone());
                 }
+                ScaleDomainSpec::FieldsSignals(fields_signals) => {
+                    signals.extend(fields_signals.fields.clone());
+                }
                 ScaleDomainSpec::Signal(signal_expr) => {
                     signals.push(signal_expr.clone());
                 }

--- a/vegafusion-rt-datafusion/tests/specs/custom/escaped_column_name1.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/escaped_column_name1.comm_plan.json
@@ -1,0 +1,4 @@
+{
+  "server_to_client": [],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/escaped_column_name1.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/escaped_column_name1.vg.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 200,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {"name": "source_0", "values": [{"'bar'": 27}]},
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"'bar'\"]) && isFinite(+datum[\"'bar'\"])"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "rect",
+      "style": ["bar"],
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "fill": {"value": "#4c78a8"},
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"\\'bar\\': \" + (format(datum[\"'bar'\"], \"\"))"
+          },
+          "xc": {"scale": "x", "field": "\\'bar\\'"},
+          "width": {"value": 5},
+          "y": {"scale": "y", "field": "\\'bar\\'"},
+          "y2": {"scale": "y", "value": 0}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": {"data": "data_0", "field": "\\'bar\\'"},
+      "range": [0, {"signal": "width"}],
+      "nice": true,
+      "zero": false,
+      "padding": 5
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "data_0", "field": "\\'bar\\'"},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "gridScale": "y",
+      "grid": true,
+      "tickCount": {"signal": "ceil(width/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "gridScale": "x",
+      "grid": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "\\'bar\\'",
+      "labelFlush": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(width/40)"},
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "\\'bar\\'",
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ]
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/layered_movies.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/layered_movies.comm_plan.json
@@ -1,0 +1,4 @@
+{
+  "server_to_client": [],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/layered_movies.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/layered_movies.vg.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 200,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {
+      "name": "big_movies",
+      "values": [
+        {
+          "title": "Avengers: Endgame",
+          "release_date": 1556236800000,
+          "release_year": 2019,
+          "tomatometer_status": "Certified-Fresh",
+          "tomatometer_rating": 94,
+          "audience_rating": 90,
+          "gross": 858373000,
+          "critic_audience_diff": 4,
+          "rt_link": "m/avengers_endgame"
+        },
+        {
+          "title": "Avatar",
+          "release_date": 1261094400000,
+          "release_year": 2009,
+          "tomatometer_status": "Certified-Fresh",
+          "tomatometer_rating": 82,
+          "audience_rating": 82,
+          "gross": 760507625,
+          "critic_audience_diff": 0,
+          "rt_link": "m/avatar"
+        },
+        {
+          "title": "Black Panther",
+          "release_date": 1518739200000,
+          "release_year": 2018,
+          "tomatometer_status": "Certified-Fresh",
+          "tomatometer_rating": 96,
+          "audience_rating": 79,
+          "gross": 700426566,
+          "critic_audience_diff": 17,
+          "rt_link": "m/black_panther_2018"
+        },
+        {
+          "title": "Avengers: Infinity War",
+          "release_date": 1524787200000,
+          "release_year": 2018,
+          "tomatometer_status": "Certified-Fresh",
+          "tomatometer_rating": 85,
+          "audience_rating": 91,
+          "gross": 678815482,
+          "critic_audience_diff": 6,
+          "rt_link": "m/avengers_infinity_war"
+        },
+        {
+          "title": "Titanic",
+          "release_date": 882489600000,
+          "release_year": 1997,
+          "tomatometer_status": "Certified-Fresh",
+          "tomatometer_rating": 89,
+          "audience_rating": 69,
+          "gross": 659363944,
+          "critic_audience_diff": 20,
+          "rt_link": "m/titanic"
+        }
+      ],
+      "format": {}
+    },
+    {
+      "name": "data_0",
+      "source": "big_movies",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "toNumber(datum[\"audience_rating\"])",
+          "as": "audience_rating"
+        },
+        {
+          "type": "formula",
+          "expr": "toNumber(datum[\"tomatometer_rating\"])",
+          "as": "tomatometer_rating"
+        },
+        {
+          "type": "extent",
+          "field": "tomatometer_rating",
+          "signal": "layer_1_bin_step_5_tomatometer_rating_extent"
+        },
+        {
+          "type": "bin",
+          "field": "tomatometer_rating",
+          "as": [
+            "bin_step_5_tomatometer_rating",
+            "bin_step_5_tomatometer_rating_end"
+          ],
+          "signal": "layer_1_bin_step_5_tomatometer_rating_bins",
+          "extent": {"signal": "layer_1_bin_step_5_tomatometer_rating_extent"},
+          "step": 5
+        },
+        {
+          "type": "extent",
+          "field": "audience_rating",
+          "signal": "layer_0_bin_step_5_audience_rating_extent"
+        },
+        {
+          "type": "bin",
+          "field": "audience_rating",
+          "as": [
+            "bin_step_5_audience_rating",
+            "bin_step_5_audience_rating_end"
+          ],
+          "signal": "layer_0_bin_step_5_audience_rating_bins",
+          "extent": {"signal": "layer_0_bin_step_5_audience_rating_extent"},
+          "step": 5
+        }
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_step_5_tomatometer_rating",
+            "bin_step_5_tomatometer_rating_end"
+          ],
+          "ops": ["mean"],
+          "fields": ["gross"],
+          "as": ["mean_gross"]
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_step_5_audience_rating",
+            "bin_step_5_audience_rating_end"
+          ],
+          "ops": ["mean"],
+          "fields": ["gross"],
+          "as": ["mean_gross"]
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "layer_0_marks",
+      "type": "line",
+      "style": ["line"],
+      "sort": {"field": "datum[\"bin_step_5_audience_rating\"]"},
+      "from": {"data": "data_2"},
+      "encode": {
+        "update": {
+          "stroke": {"value": "#C84654"},
+          "description": {
+            "signal": "\"Rating: \" + (!isValid(datum[\"bin_step_5_audience_rating\"]) || !isFinite(+datum[\"bin_step_5_audience_rating\"]) ? \"null\" : format(datum[\"bin_step_5_audience_rating\"], \"\") + \" – \" + format(datum[\"bin_step_5_audience_rating_end\"], \"\")) + \"; Median Gross: \" + (format(datum[\"mean_gross\"], \"\"))"
+          },
+          "x": {
+            "signal": "scale(\"x\", 0.5 * datum[\"bin_step_5_audience_rating\"] + 0.5 * datum[\"bin_step_5_audience_rating_end\"])"
+          },
+          "y": {"scale": "y", "field": "mean_gross"},
+          "defined": {
+            "signal": "isValid(datum[\"bin_step_5_audience_rating\"]) && isFinite(+datum[\"bin_step_5_audience_rating\"]) && isValid(datum[\"mean_gross\"]) && isFinite(+datum[\"mean_gross\"])"
+          }
+        }
+      }
+    },
+    {
+      "name": "layer_1_marks",
+      "type": "line",
+      "style": ["line"],
+      "sort": {"field": "datum[\"bin_step_5_tomatometer_rating\"]"},
+      "from": {"data": "data_1"},
+      "encode": {
+        "update": {
+          "stroke": {"value": "#2965CC"},
+          "description": {
+            "signal": "\"tomatometer_rating (binned): \" + (!isValid(datum[\"bin_step_5_tomatometer_rating\"]) || !isFinite(+datum[\"bin_step_5_tomatometer_rating\"]) ? \"null\" : format(datum[\"bin_step_5_tomatometer_rating\"], \"\") + \" – \" + format(datum[\"bin_step_5_tomatometer_rating_end\"], \"\")) + \"; Mean of gross: \" + (format(datum[\"mean_gross\"], \"\"))"
+          },
+          "x": {
+            "signal": "scale(\"x\", 0.5 * datum[\"bin_step_5_tomatometer_rating\"] + 0.5 * datum[\"bin_step_5_tomatometer_rating_end\"])"
+          },
+          "y": {"scale": "y", "field": "mean_gross"},
+          "defined": {
+            "signal": "isValid(datum[\"bin_step_5_tomatometer_rating\"]) && isFinite(+datum[\"bin_step_5_tomatometer_rating\"]) && isValid(datum[\"mean_gross\"]) && isFinite(+datum[\"mean_gross\"])"
+          }
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": {
+        "fields": [
+          {
+            "signal": "[layer_0_bin_step_5_audience_rating_bins.start, layer_0_bin_step_5_audience_rating_bins.stop]"
+          },
+          {
+            "signal": "[layer_1_bin_step_5_tomatometer_rating_bins.start, layer_1_bin_step_5_tomatometer_rating_bins.stop]"
+          }
+        ]
+      },
+      "range": [0, {"signal": "width"}],
+      "domainMax": 100,
+      "domainMin": 0,
+      "bins": {"signal": "layer_0_bin_step_5_audience_rating_bins"},
+      "zero": false
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "fields": [
+          {"data": "data_2", "field": "mean_gross"},
+          {"data": "data_1", "field": "mean_gross"}
+        ]
+      },
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "y",
+      "orient": "left",
+      "gridScale": "x",
+      "grid": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "Rating",
+      "labelFlush": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(width/10)"},
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "Median Gross",
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ]
+}

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -114,7 +114,8 @@ mod test_custom_specs {
         case("custom/ridgeline", 0.001),
         case("custom/binned_scatter", 0.001),
         case("custom/seattle_temps_heatmap", 0.001),
-        case("custom/movies_agg_parameterize", 0.001)
+        case("custom/movies_agg_parameterize", 0.001),
+        case("custom/escaped_column_name1", 0.001),
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64) {
         println!("spec_name: {}", spec_name);

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -115,7 +115,7 @@ mod test_custom_specs {
         case("custom/binned_scatter", 0.001),
         case("custom/seattle_temps_heatmap", 0.001),
         case("custom/movies_agg_parameterize", 0.001),
-        case("custom/escaped_column_name1", 0.001),
+        case("custom/escaped_column_name1", 0.001)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64) {
         println!("spec_name: {}", spec_name);

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -115,7 +115,8 @@ mod test_custom_specs {
         case("custom/binned_scatter", 0.001),
         case("custom/seattle_temps_heatmap", 0.001),
         case("custom/movies_agg_parameterize", 0.001),
-        case("custom/escaped_column_name1", 0.001)
+        case("custom/escaped_column_name1", 0.001),
+        case("custom/layered_movies", 0.001)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64) {
         println!("spec_name: {}", spec_name);


### PR DESCRIPTION
This PR adds two additional test mocks with associated fixes. Details to follow

###  `custom/escaped_column_name1` mock
This mock tests handling of columns that contain quote characters, making sure that the escape semantics match Vega.

### `layered_movies` mock
This mock previously hit an error `Unrecognized signal name: "layer_1_bin_step_5_tomatometer_rating_bins"`. This was caused by a previously unsupported structure of a scale domain specification.

```json
      "domain": {
        "fields": [
          {
            "signal": "[layer_0_bin_step_5_audience_rating_bins.start, layer_0_bin_step_5_audience_rating_bins.stop]"
          },
          {
            "signal": "[layer_1_bin_step_5_tomatometer_rating_bins.start, layer_1_bin_step_5_tomatometer_rating_bins.stop]"
          }
        ]
```