### PR TITLE
Fix invalid dataset caching in pre_transform_spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,6 +3108,7 @@ dependencies = [
 name = "vegafusion-python-embed"
 version = "0.6.0-rc5"
 dependencies = [
+ "deterministic-hash",
  "mimalloc",
  "pyo3",
  "serde",

--- a/vegafusion-core/src/data/dataset.rs
+++ b/vegafusion-core/src/data/dataset.rs
@@ -1,0 +1,34 @@
+/*
+ * VegaFusion
+ * Copyright (C) 2022 VegaFusion Technologies LLC
+ *
+ * This program is distributed under multiple licenses.
+ * Please consult the license documentation provided alongside
+ * this program the details of the active license.
+ */
+use crate::data::table::VegaFusionTable;
+use crate::error::Result;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+#[derive(Clone, Debug)]
+pub enum VegaFusionDataset {
+    Table { table: VegaFusionTable, hash: u64 },
+}
+
+impl VegaFusionDataset {
+    pub fn fingerprint(&self) -> String {
+        match self {
+            VegaFusionDataset::Table { hash, .. } => hash.to_string(),
+        }
+    }
+
+    pub fn from_table_ipc_bytes(ipc_bytes: &[u8]) -> Result<Self> {
+        // Hash ipc bytes
+        let mut hasher = deterministic_hash::DeterministicHasher::new(DefaultHasher::new());
+        ipc_bytes.hash(&mut hasher);
+        let hash = hasher.finish();
+        let table = VegaFusionTable::from_ipc_bytes(ipc_bytes)?;
+        Ok(Self::Table { table, hash })
+    }
+}

--- a/vegafusion-core/src/data/mod.rs
+++ b/vegafusion-core/src/data/mod.rs
@@ -6,6 +6,7 @@
  * Please consult the license documentation provided alongside
  * this program the details of the active license.
  */
+pub mod dataset;
 pub mod json_writer;
 pub mod scalar;
 pub mod table;

--- a/vegafusion-core/src/spec/chart.rs
+++ b/vegafusion-core/src/spec/chart.rs
@@ -6,6 +6,7 @@
  * Please consult the license documentation provided alongside
  * this program the details of the active license.
  */
+use crate::data::dataset::VegaFusionDataset;
 use crate::error::{Result, ResultWithContext, VegaFusionError};
 use crate::proto::gen::tasks::{Task, TzConfig};
 use crate::spec::data::DataSpec;
@@ -131,8 +132,12 @@ impl ChartSpec {
         Ok(visitor.task_scope)
     }
 
-    pub fn to_tasks(&self, tz_config: &TzConfig) -> Result<Vec<Task>> {
-        let mut visitor = MakeTasksVisitor::new(tz_config);
+    pub fn to_tasks(
+        &self,
+        tz_config: &TzConfig,
+        datasets: &HashMap<String, VegaFusionDataset>,
+    ) -> Result<Vec<Task>> {
+        let mut visitor = MakeTasksVisitor::new(tz_config, datasets);
         self.walk(&mut visitor)?;
         Ok(visitor.tasks)
     }

--- a/vegafusion-python-embed/Cargo.toml
+++ b/vegafusion-python-embed/Cargo.toml
@@ -8,6 +8,9 @@ version = "0.6.0-rc5"
 name = "vegafusion_embed"
 crate-type = [ "cdylib",]
 
+[dependencies.deterministic-hash]
+version="1.0.1"
+
 [dependencies.serde]
 version = "1.0.137"
 features = [ "derive",]

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -17,9 +17,9 @@ use vegafusion_core::proto::gen::services::pre_transform_result;
 use vegafusion_rt_datafusion::task_graph::runtime::TaskGraphRuntime;
 
 use serde::{Deserialize, Serialize};
-use vegafusion_core::data::table::VegaFusionTable;
 
 use mimalloc::MiMalloc;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -83,8 +83,9 @@ impl PyTaskGraphRuntime {
             .map(|(name, table_bytes)| {
                 let name = name.cast_as::<PyString>()?;
                 let ipc_bytes = table_bytes.cast_as::<PyBytes>()?;
-                let table = VegaFusionTable::from_ipc_bytes(ipc_bytes.as_bytes())?;
-                Ok((name.to_string(), table))
+                let ipc_bytes = ipc_bytes.as_bytes();
+                let dataset = VegaFusionDataset::from_table_ipc_bytes(ipc_bytes)?;
+                Ok((name.to_string(), dataset))
             })
             .collect::<PyResult<HashMap<_, _>>>()?;
 

--- a/vegafusion-rt-datafusion/benches/spec_benchmarks.rs
+++ b/vegafusion-rt-datafusion/benches/spec_benchmarks.rs
@@ -49,7 +49,10 @@ async fn eval_spec_get_variable(full_spec: ChartSpec, var: &ScopedVariable) -> Q
     };
     let spec_plan = SpecPlan::try_new(&full_spec, &Default::default()).unwrap();
     let task_scope = spec_plan.server_spec.to_task_scope().unwrap();
-    let tasks = spec_plan.server_spec.to_tasks(&tz_config).unwrap();
+    let tasks = spec_plan
+        .server_spec
+        .to_tasks(&tz_config, &Default::default())
+        .unwrap();
     let task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
     let task_graph_mapping = task_graph.build_mapping();
 
@@ -93,7 +96,10 @@ async fn eval_spec_sequence(full_spec: ChartSpec, full_updates: Vec<ExportUpdate
     // );
 
     // Build task graph
-    let tasks = spec_plan.server_spec.to_tasks(&tz_config).unwrap();
+    let tasks = spec_plan
+        .server_spec
+        .to_tasks(&tz_config, &Default::default())
+        .unwrap();
     let mut task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
     let task_graph_mapping = task_graph.build_mapping();
 

--- a/vegafusion-rt-datafusion/src/data/dataset.rs
+++ b/vegafusion-rt-datafusion/src/data/dataset.rs
@@ -1,0 +1,24 @@
+/*
+ * VegaFusion
+ * Copyright (C) 2022 VegaFusion Technologies LLC
+ *
+ * This program is distributed under multiple licenses.
+ * Please consult the license documentation provided alongside
+ * this program the details of the active license.
+ */
+use crate::data::table::VegaFusionTableUtils;
+use datafusion::prelude::DataFrame;
+use std::sync::Arc;
+use vegafusion_core::{data::dataset::VegaFusionDataset, error::Result};
+
+pub trait VegaFusionDatasetUtils {
+    fn to_dataframe(&self) -> Result<Arc<DataFrame>>;
+}
+
+impl VegaFusionDatasetUtils for VegaFusionDataset {
+    fn to_dataframe(&self) -> Result<Arc<DataFrame>> {
+        match self {
+            VegaFusionDataset::Table { table, .. } => table.to_dataframe(),
+        }
+    }
+}

--- a/vegafusion-rt-datafusion/src/data/mod.rs
+++ b/vegafusion-rt-datafusion/src/data/mod.rs
@@ -6,5 +6,6 @@
  * Please consult the license documentation provided alongside
  * this program the details of the active license.
  */
+pub mod dataset;
 pub mod table;
 pub mod tasks;

--- a/vegafusion-rt-datafusion/src/signal/mod.rs
+++ b/vegafusion-rt-datafusion/src/signal/mod.rs
@@ -12,7 +12,7 @@ use crate::expression::compiler::utils::ExprHelpers;
 use crate::task_graph::task::TaskCall;
 use async_trait::async_trait;
 use std::collections::HashMap;
-use vegafusion_core::data::table::VegaFusionTable;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 
 use crate::task_graph::timezone::RuntimeTzConfig;
 use vegafusion_core::error::Result;
@@ -26,7 +26,7 @@ impl TaskCall for SignalTask {
         &self,
         values: &[TaskValue],
         tz_config: &Option<RuntimeTzConfig>,
-        _inline_datasets: HashMap<String, VegaFusionTable>,
+        _inline_datasets: HashMap<String, VegaFusionDataset>,
     ) -> Result<(TaskValue, Vec<TaskValue>)> {
         let config = build_compilation_config(&self.input_vars(), values, tz_config);
         let expression = self.expr.as_ref().unwrap();

--- a/vegafusion-rt-datafusion/src/task_graph/task.rs
+++ b/vegafusion-rt-datafusion/src/task_graph/task.rs
@@ -10,7 +10,7 @@ use crate::task_graph::timezone::RuntimeTzConfig;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::convert::TryInto;
-use vegafusion_core::data::table::VegaFusionTable;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::tasks::task::TaskKind;
 use vegafusion_core::proto::gen::tasks::Task;
@@ -22,7 +22,7 @@ pub trait TaskCall {
         &self,
         values: &[TaskValue],
         tz_config: &Option<RuntimeTzConfig>,
-        inline_datasets: HashMap<String, VegaFusionTable>,
+        inline_datasets: HashMap<String, VegaFusionDataset>,
     ) -> Result<(TaskValue, Vec<TaskValue>)>;
 }
 
@@ -32,7 +32,7 @@ impl TaskCall for Task {
         &self,
         values: &[TaskValue],
         tz_config: &Option<RuntimeTzConfig>,
-        inline_datasets: HashMap<String, VegaFusionTable>,
+        inline_datasets: HashMap<String, VegaFusionDataset>,
     ) -> Result<(TaskValue, Vec<TaskValue>)> {
         match self.task_kind() {
             TaskKind::Value(value) => Ok((value.try_into()?, Default::default())),

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -1390,7 +1390,10 @@ async fn check_spec_sequence(
     );
 
     // Build task graph
-    let tasks = spec_plan.server_spec.to_tasks(&tz_config).unwrap();
+    let tasks = spec_plan
+        .server_spec
+        .to_tasks(&tz_config, &Default::default())
+        .unwrap();
     let mut task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
     let task_graph_mapping = task_graph.build_mapping();
 

--- a/vegafusion-rt-datafusion/tests/test_planning.rs
+++ b/vegafusion-rt-datafusion/tests/test_planning.rs
@@ -60,7 +60,9 @@ async fn test_extract_server_data() {
     let client_stubs: Vec<_> = client_inputs.difference(&client_defs).collect();
     println!("client_stubs: {:?}", client_stubs);
 
-    let tasks = server_spec.to_tasks(&tz_config).unwrap();
+    let tasks = server_spec
+        .to_tasks(&tz_config, &Default::default())
+        .unwrap();
     let graph = Arc::new(TaskGraph::new(tasks, &task_scope).unwrap());
     let mapping = graph.build_mapping();
     // println!("{:#?}", mapping);

--- a/vegafusion-rt-datafusion/tests/test_task_graph_runtime.rs
+++ b/vegafusion-rt-datafusion/tests/test_task_graph_runtime.rs
@@ -140,7 +140,7 @@ async fn try_it_from_spec() {
         default_input_tz: None,
     };
     let task_scope = chart.to_task_scope().unwrap();
-    let tasks = chart.to_tasks(&tz_config).unwrap();
+    let tasks = chart.to_tasks(&tz_config, &Default::default()).unwrap();
 
     println!("task_scope: {:?}", task_scope);
     println!("tasks: {:?}", tasks);

--- a/vegafusion-server/tests/test_task_graph_runtime.rs
+++ b/vegafusion-server/tests/test_task_graph_runtime.rs
@@ -76,7 +76,7 @@ async fn try_it_from_spec() {
         default_input_tz: None,
     };
     let task_scope = chart.to_task_scope().unwrap();
-    let tasks = chart.to_tasks(&tz_config).unwrap();
+    let tasks = chart.to_tasks(&tz_config, &Default::default()).unwrap();
 
     let graph = TaskGraph::new(tasks, &task_scope).unwrap();
     let request = QueryRequest {

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -366,7 +366,10 @@ pub fn render_vegafusion(
         local_tz,
         default_input_tz: None,
     };
-    let tasks = spec_plan.server_spec.to_tasks(&tz_config).unwrap();
+    let tasks = spec_plan
+        .server_spec
+        .to_tasks(&tz_config, &Default::default())
+        .unwrap();
     let task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
 
     // Create closure to update chart from received messages


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/vegafusion/vegafusion/pull/124.  This PR changed how inline datasets to `pre_transform_spec` are processed, and unintentionally resulted in these datasets being cached based only on their name (not their value).  This means that the inline dataset used internally was not updated when the input dataset changes across repeated calls.

This PR addresses the issue, in introducing a few new concepts:
 - The value of the data `url` property may now optionally end with a `#{fingerprint}` suffix. This fingerprint is part of the task's hash, but is ignored by the runtime when actually processing the URL.
 - A new `VegaFusionDataset` abstraction was added that represents a dataset that has a fingerprint and can be turned into a DataFrame. For now, it just wraps VegaFusionTable and the figerprint is computed as the hash of the table's contents. In the future, other data sources can be wrapped this way.  For example, a local CSV file data source could use the file modification time as the fingerprint to ensure that the file is reloaded only when updated.
 - `chart_spec.to_tasks` now accepts collection of `VegaFusionDataset`s, and when a `vegafusion+dataset://` url is encountered, a `#{fingerprint}` suffix is appended to the URL when generating the DataUrl task.

A new test from Python was added: `test_pre_transform_cache_cleared`.