### PR TITLE
Fix for stringify local datetimes with ordinal scale

### DIFF
--- a/vegafusion-core/src/planning/stringify_local_datetimes.rs
+++ b/vegafusion-core/src/planning/stringify_local_datetimes.rs
@@ -279,7 +279,7 @@ impl<'a> MutChartVisitor for StringifyLocalDatetimeFieldsVisitor<'a> {
             let source_resolved_var = (source_resolved.var, source_resolved.scope);
             if let Some(fields) = self.local_datetime_fields.get(&source_resolved_var) {
                 for field in sorted(fields) {
-                    let expr_str = format!("toDate(datum['{}'])", field);
+                    let expr_str = format!("toDate(datum['{}'], 'local')", field);
                     let transforms = &mut data.transform;
                     let transform = FormulaTransformSpec {
                         expr: expr_str,

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/datetime.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/datetime.rs
@@ -46,7 +46,9 @@ pub fn to_date_transform(
                 } else {
                     chrono_tz::Tz::from_str(input_tz_str)
                         .ok()
-                        .with_context(|| format!("Failed to parse {} as a timezone", input_tz_str))?
+                        .with_context(|| {
+                            format!("Failed to parse {} as a timezone", input_tz_str)
+                        })?
                 }
             } else {
                 return Err(VegaFusionError::parse(

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/datetime.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/datetime.rs
@@ -41,9 +41,13 @@ pub fn to_date_transform(
             // Second argument is a an override local timezone string
             let input_tz_expr = &args[1];
             if let Expr::Literal(ScalarValue::Utf8(Some(input_tz_str))) = input_tz_expr {
-                chrono_tz::Tz::from_str(input_tz_str)
-                    .ok()
-                    .with_context(|| format!("Failed to parse {} as a timezone", input_tz_str))?
+                if input_tz_str == "local" {
+                    tz_config.local_tz
+                } else {
+                    chrono_tz::Tz::from_str(input_tz_str)
+                        .ok()
+                        .with_context(|| format!("Failed to parse {} as a timezone", input_tz_str))?
+                }
             } else {
                 return Err(VegaFusionError::parse(
                     "Second argument to toDate must be a timezone string",

--- a/vegafusion-rt-datafusion/tests/test_stringify_datetimes.rs
+++ b/vegafusion-rt-datafusion/tests/test_stringify_datetimes.rs
@@ -191,7 +191,6 @@ mod test_stringify_datetimes {
         }
     }
 
-
     #[rstest(
         local_tz,
         default_input_tz,
@@ -230,7 +229,7 @@ mod test_stringify_datetimes {
         let pre_tx_result = runtime
             .pre_transform_spec(
                 &spec_str,
-                &local_tz,
+                local_tz,
                 &Some(default_input_tz.to_string()),
                 None,
                 Default::default(),

--- a/vegafusion-rt-datafusion/tests/test_stringify_datetimes.rs
+++ b/vegafusion-rt-datafusion/tests/test_stringify_datetimes.rs
@@ -191,8 +191,32 @@ mod test_stringify_datetimes {
         }
     }
 
-    #[tokio::test]
-    async fn test_local_datetime_ordinal_color() {
+
+    #[rstest(
+        local_tz,
+        default_input_tz,
+        expected_ship_date,
+        case("UTC", "UTC", "2011-01-08 00:00:00.000"),
+        case("America/New_York", "UTC", "2011-01-07 19:00:00.000"),
+        case("UTC", "America/New_York", "2011-01-08 00:00:00.000")
+    )]
+    fn test_local_datetime_ordinal_color(
+        local_tz: &str,
+        default_input_tz: &str,
+        expected_ship_date: &str,
+    ) {
+        TOKIO_RUNTIME.block_on(check_local_datetime_ordinal_color(
+            local_tz,
+            default_input_tz,
+            expected_ship_date,
+        ));
+    }
+
+    async fn check_local_datetime_ordinal_color(
+        local_tz: &str,
+        default_input_tz: &str,
+        expected_ship_date: &str,
+    ) {
         // Load spec
         let spec_path = format!(
             "{}/tests/specs/pre_transform/shipping_mixed_scales.vg.json",
@@ -202,15 +226,12 @@ mod test_stringify_datetimes {
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
-        // let local_tz = "America/New_York".to_string();
-        let local_tz = "UTC".to_string();
-        let default_input_tz = "UTC".to_string();
 
         let pre_tx_result = runtime
             .pre_transform_spec(
                 &spec_str,
                 &local_tz,
-                &Some(default_input_tz),
+                &Some(default_input_tz.to_string()),
                 None,
                 Default::default(),
             )
@@ -230,7 +251,6 @@ mod test_stringify_datetimes {
                 let first = values[0].as_object().expect("Expected object");
 
                 // Check hours_time
-                let expected_ship_date = "2011-01-08 00:00:00.000";
                 let hours_time = first
                     .get("ship_date")
                     .expect("Expected ship_date")
@@ -245,7 +265,6 @@ mod test_stringify_datetimes {
                 let values = data.as_array().expect("Expected array");
                 let first = values[0].as_object().expect("Expected object");
 
-                let expected_ship_date = "2011-01-08 00:00:00.000";
                 let hours_time = first
                     .get("ship_date")
                     .expect("Expected ship_date")


### PR DESCRIPTION
Followup fix for https://github.com/vegafusion/vegafusion/pull/128