### PR TITLE
Add stack transform for offset=zero

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -152,10 +152,11 @@ jobs:
       - name: Build wheels
         uses: messense/maturin-action@v1
         with:
-          maturin-version: latest
+          maturin-version: 0.12.20
           command: build
+          manylinux: 2010
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.10 -i python3.9 -i python3.8 -i python3.7 --manylinux 2010 -- -Z oom=panic
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.10 -i python3.9 -i python3.8 -i python3.7 --rustc-extra-args="-Z oom=panic"
       - name: Download Apple Silicon toolchain
         if: ${{ runner.os == 'macOS' }}
         run: |
@@ -164,10 +165,10 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         uses: messense/maturin-action@v1
         with:
-          maturin-version: latest
+          maturin-version: 0.12.20
           command: build
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin -i python3.10 -i python3.9 -i python3.8 -i python3.7 -- -Z oom=panic
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin -i python3.10 -i python3.9 -i python3.8 -i python3.7 --rustc-extra-args="-Z oom=panic"
       - name: Remove unwanted universal
         if: ${{ runner.os == 'macOS' }}
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -156,7 +156,7 @@ jobs:
           command: build
           manylinux: 2010
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip -- -Z oom=panic
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.10 -i python3.9 -i python3.8 -i python3.7 -- -Z oom=panic
       - name: Download Apple Silicon toolchain
         if: ${{ runner.os == 'macOS' }}
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -154,9 +154,8 @@ jobs:
         with:
           maturin-version: latest
           command: build
-          manylinux: 2010
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.10 -i python3.9 -i python3.8 -i python3.7 -- -Z oom=panic
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.10 -i python3.9 -i python3.8 -i python3.7 --manylinux 2010 -- -Z oom=panic
       - name: Download Apple Silicon toolchain
         if: ${{ runner.os == 'macOS' }}
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -156,7 +156,7 @@ jobs:
           command: build
           manylinux: 2010
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip --rustc-extra-args="-Z oom=panic"
+          args: --release -m vegafusion-python-embed/Cargo.toml --rustc-extra-args="-Z oom=panic" --strip
       - name: Download Apple Silicon toolchain
         if: ${{ runner.os == 'macOS' }}
         run: |
@@ -168,7 +168,7 @@ jobs:
           maturin-version: latest
           command: build
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip --rustc-extra-args="-Z oom=panic" --target aarch64-apple-darwin -i python3.10 -i python3.9 -i python3.8 -i python3.7
+          args: --release -m vegafusion-python-embed/Cargo.toml --rustc-extra-args="-Z oom=panic" --strip --target aarch64-apple-darwin -i python3.10 -i python3.9 -i python3.8 -i python3.7
       - name: Remove unwanted universal
         if: ${{ runner.os == 'macOS' }}
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -156,7 +156,7 @@ jobs:
           command: build
           manylinux: 2010
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --rustc-extra-args="-Z oom=panic" --strip
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip -- -Z oom=panic
       - name: Download Apple Silicon toolchain
         if: ${{ runner.os == 'macOS' }}
         run: |
@@ -168,7 +168,7 @@ jobs:
           maturin-version: latest
           command: build
           rust-toolchain: nightly
-          args: --release -m vegafusion-python-embed/Cargo.toml --rustc-extra-args="-Z oom=panic" --strip --target aarch64-apple-darwin -i python3.10 -i python3.9 -i python3.8 -i python3.7
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin -i python3.10 -i python3.9 -i python3.8 -i python3.7 -- -Z oom=panic
       - name: Remove unwanted universal
         if: ${{ runner.os == 'macOS' }}
         run: |

--- a/vegafusion-core/src/proto/prost_gen/transforms.rs
+++ b/vegafusion-core/src/proto/prost_gen/transforms.rs
@@ -153,17 +153,34 @@ pub struct WindowFrame {
     #[prost(int64, optional, tag="2")]
     pub end: ::core::option::Option<i64>,
 }
-// Project
-
+/// Project
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Project {
     #[prost(string, repeated, tag="1")]
     pub fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Stack
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Stack {
+    #[prost(string, tag="1")]
+    pub field: ::prost::alloc::string::String,
+    #[prost(enumeration="StackOffset", tag="2")]
+    pub offset: i32,
+    #[prost(enumeration="SortOrder", repeated, tag="3")]
+    pub sort: ::prost::alloc::vec::Vec<i32>,
+    #[prost(string, repeated, tag="4")]
+    pub sort_fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, repeated, tag="5")]
+    pub groupby: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="6")]
+    pub alias_0: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="7")]
+    pub alias_1: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// Top-level transform
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transform {
-    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
     pub transform_kind: ::core::option::Option<transform::TransformKind>,
 }
 /// Nested message and enum types in `Transform`.
@@ -190,6 +207,8 @@ pub mod transform {
         Window(super::Window),
         #[prost(message, tag="10")]
         Project(super::Project),
+        #[prost(message, tag="11")]
+        Stack(super::Stack),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -268,4 +287,11 @@ pub enum WindowOp {
     NthValue = 10,
     PrevValue = 11,
     NextValue = 12,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum StackOffset {
+    Zero = 0,
+    Center = 1,
+    Normalize = 2,
 }

--- a/vegafusion-core/src/proto/tonic_gen/transforms.rs
+++ b/vegafusion-core/src/proto/tonic_gen/transforms.rs
@@ -153,17 +153,34 @@ pub struct WindowFrame {
     #[prost(int64, optional, tag="2")]
     pub end: ::core::option::Option<i64>,
 }
-// Project
-
+/// Project
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Project {
     #[prost(string, repeated, tag="1")]
     pub fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Stack
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Stack {
+    #[prost(string, tag="1")]
+    pub field: ::prost::alloc::string::String,
+    #[prost(enumeration="StackOffset", tag="2")]
+    pub offset: i32,
+    #[prost(enumeration="SortOrder", repeated, tag="3")]
+    pub sort: ::prost::alloc::vec::Vec<i32>,
+    #[prost(string, repeated, tag="4")]
+    pub sort_fields: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, repeated, tag="5")]
+    pub groupby: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="6")]
+    pub alias_0: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="7")]
+    pub alias_1: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// Top-level transform
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transform {
-    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
     pub transform_kind: ::core::option::Option<transform::TransformKind>,
 }
 /// Nested message and enum types in `Transform`.
@@ -190,6 +207,8 @@ pub mod transform {
         Window(super::Window),
         #[prost(message, tag="10")]
         Project(super::Project),
+        #[prost(message, tag="11")]
+        Stack(super::Stack),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -268,4 +287,11 @@ pub enum WindowOp {
     NthValue = 10,
     PrevValue = 11,
     NextValue = 12,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum StackOffset {
+    Zero = 0,
+    Center = 1,
+    Normalize = 2,
 }

--- a/vegafusion-core/src/proto/transforms.proto
+++ b/vegafusion-core/src/proto/transforms.proto
@@ -185,9 +185,25 @@ message WindowFrame {
 }
 
 // Project
-
 message Project {
   repeated string fields = 1;
+}
+
+// Stack
+message Stack {
+  string field = 1;
+  StackOffset offset = 2;
+  repeated SortOrder sort = 3;
+  repeated string sort_fields = 4;
+  repeated string groupby = 5;
+  optional string alias_0 = 6;
+  optional string alias_1 = 7;
+}
+
+enum StackOffset {
+  Zero = 0;
+  Center = 1;
+  Normalize = 2;
 }
 
 // Top-level transform
@@ -203,6 +219,7 @@ message Transform {
     JoinAggregate joinaggregate = 8;
     Window window = 9;
     Project project = 10;
+    Stack stack = 11;
   }
 }
 

--- a/vegafusion-core/src/spec/transform/mod.rs
+++ b/vegafusion-core/src/spec/transform/mod.rs
@@ -16,6 +16,7 @@ pub mod joinaggregate;
 pub mod lookup;
 pub mod project;
 pub mod sequence;
+pub mod stack;
 pub mod timeunit;
 pub mod unsupported;
 pub mod window;
@@ -32,6 +33,7 @@ use crate::spec::transform::joinaggregate::JoinAggregateTransformSpec;
 use crate::spec::transform::lookup::LookupTransformSpec;
 use crate::spec::transform::project::ProjectTransformSpec;
 use crate::spec::transform::sequence::SequenceTransformSpec;
+use crate::spec::transform::stack::StackTransformSpec;
 use crate::spec::transform::timeunit::TimeUnitTransformSpec;
 use crate::spec::transform::unsupported::*;
 use crate::spec::transform::window::WindowTransformSpec;
@@ -54,6 +56,7 @@ pub enum TransformSpec {
     JoinAggregate(JoinAggregateTransformSpec),
     Window(WindowTransformSpec),
     Project(ProjectTransformSpec),
+    /**/ Stack(StackTransformSpec),
 
     // Unsupported
     CountPattern(CountpatternTransformSpec),
@@ -90,7 +93,6 @@ pub enum TransformSpec {
     ResolveFilter(ResolvefilterTransformSpec),
     Sample(SampleTransformSpec),
     Sequence(SequenceTransformSpec),
-    Stack(StackTransformSpec),
     Stratify(StratifyTransformSpec),
     Tree(TreeTransformSpec),
     TreeLinks(TreelinksTransformSpec),
@@ -112,6 +114,7 @@ impl Deref for TransformSpec {
             TransformSpec::Collect(t) => t,
             TransformSpec::Timeunit(t) => t,
             TransformSpec::Project(t) => t,
+            TransformSpec::Stack(t) => t,
 
             // Supported for dependency determination, not implementation
             TransformSpec::Lookup(t) => t,
@@ -151,7 +154,6 @@ impl Deref for TransformSpec {
             TransformSpec::Regression(t) => t,
             TransformSpec::ResolveFilter(t) => t,
             TransformSpec::Sample(t) => t,
-            TransformSpec::Stack(t) => t,
             TransformSpec::Stratify(t) => t,
             TransformSpec::Tree(t) => t,
             TransformSpec::TreeLinks(t) => t,

--- a/vegafusion-core/src/spec/transform/stack.rs
+++ b/vegafusion-core/src/spec/transform/stack.rs
@@ -1,0 +1,95 @@
+/*
+ * VegaFusion
+ * Copyright (C) 2022 VegaFusion Technologies LLC
+ *
+ * This program is distributed under multiple licenses.
+ * Please consult the license documentation provided alongside
+ * this program the details of the active license.
+ */
+
+use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::spec::transform::{TransformColumns, TransformSpecTrait};
+use crate::spec::values::{CompareSpec, Field};
+use crate::task_graph::graph::ScopedVariable;
+use crate::task_graph::scope::TaskScope;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StackTransformSpec {
+    pub field: Field,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groupby: Option<Vec<Field>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<CompareSpec>,
+
+    #[serde(rename = "as", skip_serializing_if = "Option::is_none")]
+    pub as_: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<StackOffsetSpec>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl StackTransformSpec {
+    pub fn as_(&self) -> Vec<String> {
+        self.as_
+            .clone()
+            .unwrap_or_else(|| vec!["y0".to_string(), "y1".to_string()])
+    }
+
+    pub fn offset(&self) -> StackOffsetSpec {
+        self.offset.clone().unwrap_or(StackOffsetSpec::Zero)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StackOffsetSpec {
+    Zero,
+    Center,
+    Normalize,
+}
+
+impl TransformSpecTrait for StackTransformSpec {
+    fn supported(&self) -> bool {
+        self.offset() == StackOffsetSpec::Zero
+    }
+
+    fn transform_columns(
+        &self,
+        datum_var: &Option<ScopedVariable>,
+        _usage_scope: &[u32],
+        _task_scope: &TaskScope,
+        _vl_selection_fields: &VlSelectionFields,
+    ) -> TransformColumns {
+        if let Some(datum_var) = datum_var {
+            // Init column usage with field
+            let mut col_usage = ColumnUsage::from(self.field.field().as_str());
+
+            // Add groupby usage
+            if let Some(groupby) = self.groupby.as_ref() {
+                let groupby: Vec<_> = groupby.iter().map(|field| field.field()).collect();
+                col_usage = col_usage.union(&ColumnUsage::from(groupby.as_slice()));
+            }
+
+            // Add sort usage
+            if let Some(compares) = self.sort.as_ref() {
+                col_usage = col_usage.union(&ColumnUsage::from(compares.field.to_vec().as_slice()));
+            }
+
+            // Build produced
+            let produced = ColumnUsage::from(self.as_().as_slice());
+
+            let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);
+            TransformColumns::PassThrough { usage, produced }
+        } else {
+            TransformColumns::Unknown
+        }
+    }
+}

--- a/vegafusion-core/src/spec/transform/unsupported.rs
+++ b/vegafusion-core/src/spec/transform/unsupported.rs
@@ -61,7 +61,6 @@ unsupported_transforms!(
     RegressionTransformSpec,
     ResolvefilterTransformSpec,
     SampleTransformSpec,
-    StackTransformSpec,
     StratifyTransformSpec,
     TreeTransformSpec,
     TreelinksTransformSpec,

--- a/vegafusion-core/src/transform/mod.rs
+++ b/vegafusion-core/src/transform/mod.rs
@@ -10,7 +10,7 @@ use crate::error::VegaFusionError;
 use crate::proto::gen::tasks::Variable;
 use crate::proto::gen::transforms::transform::TransformKind;
 use crate::proto::gen::transforms::{
-    Aggregate, Bin, Collect, Extent, Filter, Formula, Project, TimeUnit,
+    Aggregate, Bin, Collect, Extent, Filter, Formula, Project, Stack, TimeUnit,
 };
 use crate::proto::gen::transforms::{JoinAggregate, Transform, Window};
 use crate::spec::transform::TransformSpec;
@@ -26,6 +26,7 @@ pub mod formula;
 pub mod joinaggregate;
 pub mod pipeline;
 pub mod project;
+pub mod stack;
 pub mod timeunit;
 pub mod window;
 
@@ -46,6 +47,7 @@ impl TryFrom<&TransformSpec> for TransformKind {
             }
             TransformSpec::Window(tx_spec) => Self::Window(Window::try_new(tx_spec)?),
             TransformSpec::Project(tx_spec) => Self::Project(Project::try_new(tx_spec)?),
+            TransformSpec::Stack(tx_spec) => Self::Stack(Stack::try_new(tx_spec)?),
             _ => {
                 return Err(VegaFusionError::parse(&format!(
                     "Unsupported transform: {:?}",
@@ -79,6 +81,7 @@ impl TransformKind {
             TransformKind::Joinaggregate(tx) => tx,
             TransformKind::Window(tx) => tx,
             TransformKind::Project(tx) => tx,
+            TransformKind::Stack(tx) => tx,
         }
     }
 }

--- a/vegafusion-core/src/transform/stack.rs
+++ b/vegafusion-core/src/transform/stack.rs
@@ -1,0 +1,71 @@
+/*
+ * VegaFusion
+ * Copyright (C) 2022 VegaFusion Technologies LLC
+ *
+ * This program is distributed under multiple licenses.
+ * Please consult the license documentation provided alongside
+ * this program the details of the active license.
+ */
+use crate::error::Result;
+use crate::proto::gen::transforms::{SortOrder, Stack, StackOffset};
+use crate::spec::transform::stack::{StackOffsetSpec, StackTransformSpec};
+use crate::spec::values::SortOrderSpec;
+use crate::transform::TransformDependencies;
+
+impl Stack {
+    pub fn try_new(spec: &StackTransformSpec) -> Result<Self> {
+        // Extract offset
+        let offset = match spec.offset() {
+            StackOffsetSpec::Zero => StackOffset::Zero,
+            StackOffsetSpec::Center => StackOffset::Center,
+            StackOffsetSpec::Normalize => StackOffset::Normalize,
+        };
+
+        // Extract sort fields
+        let sort_fields = spec
+            .sort
+            .as_ref()
+            .map(|compare| compare.field.to_vec())
+            .unwrap_or_default();
+
+        // Extract sort order
+        let sort = spec
+            .sort
+            .as_ref()
+            .and_then(|compare| compare.order.clone())
+            .map(|order| {
+                order
+                    .to_vec()
+                    .iter()
+                    .map(|order| match order {
+                        SortOrderSpec::Descending => SortOrder::Descending as i32,
+                        SortOrderSpec::Ascending => SortOrder::Ascending as i32,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        // Extract groupby fields
+        let groupby = spec
+            .groupby
+            .as_ref()
+            .map(|fields| fields.iter().map(|field| field.field()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        // Extract aliases
+        let alias0 = spec.as_().get(0).cloned().unwrap_or("y0".to_string());
+        let alias1 = spec.as_().get(1).cloned().unwrap_or("y1".to_string());
+
+        Ok(Self {
+            field: spec.field.field(),
+            offset: offset as i32,
+            sort,
+            sort_fields,
+            groupby,
+            alias_0: Some(alias0),
+            alias_1: Some(alias1),
+        })
+    }
+}
+
+impl TransformDependencies for Stack {}

--- a/vegafusion-core/src/transform/stack.rs
+++ b/vegafusion-core/src/transform/stack.rs
@@ -53,8 +53,8 @@ impl Stack {
             .unwrap_or_default();
 
         // Extract aliases
-        let alias0 = spec.as_().get(0).cloned().unwrap_or("y0".to_string());
-        let alias1 = spec.as_().get(1).cloned().unwrap_or("y1".to_string());
+        let alias0 = spec.as_().get(0).cloned().unwrap_or_else(|| "y0".to_string());
+        let alias1 = spec.as_().get(1).cloned().unwrap_or_else(|| "y1".to_string());
 
         Ok(Self {
             field: spec.field.field(),

--- a/vegafusion-core/src/transform/stack.rs
+++ b/vegafusion-core/src/transform/stack.rs
@@ -53,8 +53,16 @@ impl Stack {
             .unwrap_or_default();
 
         // Extract aliases
-        let alias0 = spec.as_().get(0).cloned().unwrap_or_else(|| "y0".to_string());
-        let alias1 = spec.as_().get(1).cloned().unwrap_or_else(|| "y1".to_string());
+        let alias0 = spec
+            .as_()
+            .get(0)
+            .cloned()
+            .unwrap_or_else(|| "y0".to_string());
+        let alias1 = spec
+            .as_()
+            .get(1)
+            .cloned()
+            .unwrap_or_else(|| "y1".to_string());
 
         Ok(Self {
             field: spec.field.field(),

--- a/vegafusion-rt-datafusion/src/transform/mod.rs
+++ b/vegafusion-rt-datafusion/src/transform/mod.rs
@@ -15,6 +15,7 @@ pub mod formula;
 pub mod joinaggregate;
 pub mod pipeline;
 pub mod project;
+pub mod stack;
 pub mod timeunit;
 pub mod utils;
 pub mod window;
@@ -52,6 +53,7 @@ pub fn to_transform_trait(tx: &TransformKind) -> &dyn TransformTrait {
         TransformKind::Joinaggregate(tx) => tx,
         TransformKind::Window(tx) => tx,
         TransformKind::Project(tx) => tx,
+        TransformKind::Stack(tx) => tx,
     }
 }
 

--- a/vegafusion-rt-datafusion/src/transform/stack.rs
+++ b/vegafusion-rt-datafusion/src/transform/stack.rs
@@ -1,0 +1,136 @@
+/*
+ * VegaFusion
+ * Copyright (C) 2022 VegaFusion Technologies LLC
+ *
+ * This program is distributed under multiple licenses.
+ * Please consult the license documentation provided alongside
+ * this program the details of the active license.
+ */
+use crate::expression::compiler::config::CompilationConfig;
+use crate::expression::compiler::utils::to_numeric;
+use crate::transform::TransformTrait;
+use async_trait::async_trait;
+use datafusion::dataframe::DataFrame;
+use datafusion::physical_plan::aggregates;
+use datafusion_expr::{case, col, lit, when, BuiltInWindowFunction, Expr, WindowFunction};
+use std::ops::{Add, Sub};
+use std::sync::Arc;
+use vegafusion_core::error::Result;
+use vegafusion_core::proto::gen::transforms::{SortOrder, Stack};
+use vegafusion_core::task_graph::task_value::TaskValue;
+
+#[async_trait]
+impl TransformTrait for Stack {
+    async fn eval(
+        &self,
+        dataframe: Arc<DataFrame>,
+        _config: &CompilationConfig,
+    ) -> Result<(Arc<DataFrame>, Vec<TaskValue>)> {
+        // Assume offset is Zero until others are implemented
+
+        let alias0 = self.alias_0.clone().expect("alias0 expected");
+        let alias1 = self.alias_1.clone().expect("alias1 expected");
+
+        let mut order_by: Vec<_> = self
+            .sort_fields
+            .iter()
+            .zip(&self.sort)
+            .map(|(field, order)| Expr::Sort {
+                expr: Box::new(col(field)),
+                asc: *order == SortOrder::Ascending as i32,
+                nulls_first: *order == SortOrder::Ascending as i32,
+            })
+            .collect();
+
+        // Save off input columns
+        let input_fields: Vec<_> = dataframe
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.field().name().clone())
+            .collect();
+
+        // Build first selection
+        let mut selection_0: Vec<_> = input_fields
+            .iter()
+            .filter_map(|field| {
+                if field == &alias0 || field == &alias1 {
+                    None
+                } else {
+                    Some(col(field))
+                }
+            })
+            .collect();
+
+        //  If no order by fields provided, use the row number
+        let row_number_expr = Expr::WindowFunction {
+            fun: WindowFunction::BuiltInWindowFunction(BuiltInWindowFunction::RowNumber),
+            args: Vec::new(),
+            partition_by: Vec::new(),
+            order_by: Vec::new(),
+            window_frame: None,
+        }
+        .alias("__row_number");
+        selection_0.push(col("__row_number"));
+        let dataframe = dataframe.select(vec![Expr::Wildcard, row_number_expr])?;
+
+        // Order by row number last (and only if no explicit ordering provided)
+        order_by.push(Expr::Sort {
+            expr: Box::new(col("__row_number")),
+            asc: true,
+            nulls_first: true,
+        });
+
+        // Build groupby columns
+        let partition_by: Vec<_> = self.groupby.iter().map(|group| col(group)).collect();
+
+        // Build window expression
+        let fun = WindowFunction::AggregateFunction(aggregates::AggregateFunction::Sum);
+
+        // Case field to number and replace with 0 when null
+        let numeric_field = to_numeric(col(&self.field), dataframe.schema())?;
+        let numeric_field =
+            when(col(&self.field).is_not_null(), numeric_field).otherwise(lit(0.0))?;
+
+        let window_expr = Expr::WindowFunction {
+            fun,
+            args: vec![numeric_field.clone()],
+            partition_by,
+            order_by,
+            window_frame: None,
+        }
+        .alias(&alias1);
+
+        selection_0.push(window_expr);
+
+        let dataframe = dataframe.select(selection_0.clone())?;
+
+        // Restore original order
+        let dataframe = dataframe.sort(vec![Expr::Sort {
+            expr: Box::new(col("__row_number")),
+            asc: true,
+            nulls_first: false,
+        }])?;
+
+        // Build selection_1
+        let mut selection_1: Vec<_> = input_fields
+            .iter()
+            .filter_map(|field| {
+                if field == &alias0 || field == &alias1 {
+                    None
+                } else {
+                    Some(col(field))
+                }
+            })
+            .collect();
+
+        // Now compute alias1 column by adding numeric field to alias0
+        let alias0_col = col(&alias1).sub(numeric_field).alias(&alias0);
+        selection_1.push(alias0_col);
+        selection_1.push(col(&alias1));
+
+        let dataframe = dataframe.select(selection_1.clone())?;
+
+        Ok((dataframe, Default::default()))
+    }
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/difference_from_mean.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/difference_from_mean.comm_plan.json
@@ -2,12 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "data_1",
+      "name": "data_0",
       "scope": []
-    },
-    {
+    }, {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_0_y_domain_Title",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_1",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/joinaggregate_movie_rating.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/joinaggregate_movie_rating.comm_plan.json
@@ -2,12 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "data_1",
+      "name": "data_0",
       "scope": []
-    },
-    {
+    }, {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/relative_frequency_histogram.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/relative_frequency_histogram.comm_plan.json
@@ -2,7 +2,7 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar.comm_plan.json
@@ -2,7 +2,7 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_month.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_month.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_utcmonth_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_timeunit_parameterize.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_timeunit_parameterize.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_utcmonth_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_timeunit_parameterize_local.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_timeunit_parameterize_local.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_utcmonth_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_year.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_weather_year.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_year_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/custom/trellis_stacked_bar.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/trellis_stacked_bar.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "column_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_y_domain_variety",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/arc_facet.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/arc_facet.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "column_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/area_overlay.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/area_overlay.comm_plan.json
@@ -2,6 +2,10 @@
   "server_to_client": [
     {
       "namespace": "data",
+      "name": "data_1",
+      "scope": []
+    }, {
+      "namespace": "data",
       "name": "source_0",
       "scope": []
     }

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/bar_aggregate_transform.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/bar_aggregate_transform.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_Cylinders",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/bar_diverging_stack_population_pyramid.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/bar_diverging_stack_population_pyramid.comm_plan.json
@@ -2,10 +2,13 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_data_0",
+      "name": "data_0",
       "scope": []
-    },
-    {
+    }, {
+      "namespace": "data",
+      "name": "data_0_color_domain_gender",
+      "scope": []
+    }, {
       "namespace": "data",
       "name": "source_0_y_domain_age",
       "scope": []

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/bar_grouped_stacked.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/bar_grouped_stacked.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_year_Year",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_xOffset_domain_Origin",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_Cylinders",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/concat_population_pyramid.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/concat_population_pyramid.comm_plan.json
@@ -2,30 +2,25 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_data_2",
-      "scope": []
-    },
-    {
-      "namespace": "data",
-      "name": "_server_data_4",
-      "scope": []
-    },
-    {
-      "namespace": "data",
       "name": "data_1_concat_0_y_domain_age",
       "scope": []
-    },
-    {
+    }, {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    }, {
       "namespace": "data",
       "name": "data_3_concat_2_y_domain_age",
       "scope": []
-    },
-    {
+    }, {
+      "namespace": "data",
+      "name": "data_4",
+      "scope": []
+    }, {
       "namespace": "data",
       "name": "source_0",
       "scope": []
-    },
-    {
+    }, {
       "namespace": "data",
       "name": "source_0_concat_1_y_domain_age",
       "scope": []

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/facet_custom.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/facet_custom.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "column_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/facet_custom_header.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/facet_custom_header.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "column_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/facet_independent_scale.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/facet_independent_scale.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "column_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/histogram_rel_freq.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/histogram_rel_freq.comm_plan.json
@@ -2,7 +2,7 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/joinaggregate_mean_difference.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/joinaggregate_mean_difference.comm_plan.json
@@ -2,12 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "data_1",
+      "name": "data_0",
       "scope": []
-    },
-    {
+    }, {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_0_y_domain_Title",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_1",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/joinaggregate_mean_difference_by_year.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/joinaggregate_mean_difference_by_year.comm_plan.json
@@ -2,12 +2,12 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "data_1",
+      "name": "data_0",
       "scope": []
     },
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/repeat_histogram.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/repeat_histogram.comm_plan.json
@@ -22,22 +22,22 @@
     },
     {
       "namespace": "data",
-      "name": "_server_data_0",
+      "name": "data_0",
       "scope": []
     },
     {
       "namespace": "data",
-      "name": "_server_data_1",
+      "name": "data_1",
       "scope": []
     },
     {
       "namespace": "data",
-      "name": "_server_data_2",
+      "name": "data_2",
       "scope": []
     },
     {
       "namespace": "data",
-      "name": "_server_data_3",
+      "name": "data_3",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_1d.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_1d.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_Origin",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_weather",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_month_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_config.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_config.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_weather",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_month_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_mark.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_mark.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_weather",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_month_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_mark_x.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_mark_x.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_weather",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_y_domain_month_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_stroke.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_count_corner_radius_stroke.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_weather",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_month_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_y_domain_variety",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_order.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_order.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_y_domain_variety",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_order_custom.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_order_custom.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_y_domain_variety",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_population.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_population.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_size.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_size.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_size_domain_weather",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_month_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_sum_opacity.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_sum_opacity.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_opacity_domain_people",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_v.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_v.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_variety",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_weather.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_weather.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_month_date",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_bar.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_bar.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "row_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_bar_no_header.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_bar_no_header.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "row_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_stacked_bar.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_stacked_bar.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "column_domain",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_y_domain_variety",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -272,7 +272,10 @@ mod test_vega_specs {
         // case("vega/playfair", 0.001),
 
         case("vega/population", 0.001),
-        case("vega/quantile-dot-plot", 0.001),
+
+        //  // "field" property of stack transform is required
+        // case("vega/quantile-dot-plot", 0.001),
+
         case("vega/regression", 0.001),
         case("vega/scales-discretize", 0.001),
         case("vega/scatter-brush-filter", 0.001),

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -809,7 +809,7 @@ mod test_vegalite_specs {
         case("vegalite/stacked_bar_h_normalized_labeled", 0.001),
 
         // (Legend matches, but difference stack order)
-        case("vegalite/stacked_bar_h_order_custom", 0.3),
+        case("vegalite/stacked_bar_h_order_custom", 0.001),
 
         case("vegalite/stacked_bar_h_order", 0.001),
         case("vegalite/stacked_bar_h", 0.001),

--- a/vegafusion-rt-datafusion/tests/test_transform_stack.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_stack.rs
@@ -1,0 +1,119 @@
+/*
+ * VegaFusion
+ * Copyright (C) 2022 VegaFusion Technologies LLC
+ *
+ * This program is distributed under multiple licenses.
+ * Please consult the license documentation provided alongside
+ * this program the details of the active license.
+ */
+#[macro_use]
+extern crate lazy_static;
+
+mod util;
+
+use util::check::check_transform_evaluation;
+use util::datasets::vega_json_dataset;
+use util::equality::TablesEqualConfig;
+
+use vegafusion_core::spec::transform::bin::{BinExtent, BinTransformSpec};
+use vegafusion_core::spec::transform::stack::StackTransformSpec;
+use vegafusion_core::spec::transform::TransformSpec;
+use vegafusion_core::spec::values::{
+    CompareSpec, Field, SignalExpressionSpec, SortOrderOrList, SortOrderSpec, StringOrStringList,
+};
+
+#[test]
+fn test_stack() {
+    let dataset = vega_json_dataset("penguins");
+
+    let stack_spec = StackTransformSpec {
+        field: Field::String("Body Mass (g)".to_string()),
+        groupby: None,
+        sort: None,
+        as_: None,
+        offset: None,
+        extra: Default::default(),
+    };
+
+    let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+
+    let comp_config = Default::default();
+    let eq_config = TablesEqualConfig {
+        row_order: true,
+        ..Default::default()
+    };
+
+    check_transform_evaluation(
+        &dataset,
+        transform_specs.as_slice(),
+        &comp_config,
+        &eq_config,
+    );
+}
+
+#[test]
+fn test_stack_with_group() {
+    let dataset = vega_json_dataset("penguins");
+
+    let stack_spec = StackTransformSpec {
+        field: Field::String("Body Mass (g)".to_string()),
+        groupby: Some(vec![Field::String("Species".to_string())]),
+        sort: None,
+        as_: None,
+        offset: None,
+        extra: Default::default(),
+    };
+
+    let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+
+    let comp_config = Default::default();
+    let eq_config = TablesEqualConfig {
+        row_order: true,
+        ..Default::default()
+    };
+
+    check_transform_evaluation(
+        &dataset,
+        transform_specs.as_slice(),
+        &comp_config,
+        &eq_config,
+    );
+}
+
+#[test]
+fn test_stack_with_group_sort() {
+    let dataset = vega_json_dataset("penguins");
+
+    let stack_spec = StackTransformSpec {
+        field: Field::String("Body Mass (g)".to_string()),
+        groupby: Some(vec![Field::String("Species".to_string())]),
+        sort: Some(CompareSpec {
+            field: StringOrStringList::StringList(vec![
+                "Sex".to_string(),
+                "Flipper Length (mm)".to_string(),
+            ]),
+            order: Some(SortOrderOrList::SortOrderList(vec![
+                SortOrderSpec::Ascending,
+                SortOrderSpec::Descending,
+            ])),
+        }),
+        as_: Some(vec!["foo".to_string(), "bar".to_string()]),
+        offset: None,
+        extra: Default::default(),
+    };
+
+    let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+
+    let comp_config = Default::default();
+    let eq_config = TablesEqualConfig {
+        row_order: true,
+        ..Default::default()
+    };
+
+    check_transform_evaluation(
+        &dataset,
+        transform_specs.as_slice(),
+        &comp_config,
+        &eq_config,
+    );
+}

--- a/vegafusion-rt-datafusion/tests/test_transform_stack.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_stack.rs
@@ -15,11 +15,10 @@ use util::check::check_transform_evaluation;
 use util::datasets::vega_json_dataset;
 use util::equality::TablesEqualConfig;
 
-use vegafusion_core::spec::transform::bin::{BinExtent, BinTransformSpec};
 use vegafusion_core::spec::transform::stack::StackTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_core::spec::values::{
-    CompareSpec, Field, SignalExpressionSpec, SortOrderOrList, SortOrderSpec, StringOrStringList,
+    CompareSpec, Field, SortOrderOrList, SortOrderSpec, StringOrStringList,
 };
 
 #[test]


### PR DESCRIPTION
This PR adds an initial implementation of the [`stack`](https://vega.github.io/vega/docs/transforms/stack/) transform for the case where `offset` equals `zero`.  A follow-on PR will add support for the `center` and `normalize` offset values.
