### PR TITLE
Add support for stack transform with normalize and center offsets

### DIFF
--- a/vegafusion-core/src/spec/transform/stack.rs
+++ b/vegafusion-core/src/spec/transform/stack.rs
@@ -57,10 +57,6 @@ pub enum StackOffsetSpec {
 }
 
 impl TransformSpecTrait for StackTransformSpec {
-    fn supported(&self) -> bool {
-        self.offset() == StackOffsetSpec::Zero
-    }
-
     fn transform_columns(
         &self,
         datum_var: &Option<ScopedVariable>,

--- a/vegafusion-rt-datafusion/src/transform/stack.rs
+++ b/vegafusion-rt-datafusion/src/transform/stack.rs
@@ -170,7 +170,7 @@ fn eval_normalize_center_offset(
         let groupby_aliases: Vec<String> = partition_by
             .iter()
             .enumerate()
-            .map(|(i, _a)| format!("grp_field_{}", i))
+            .map(|(i, _a)| format!("grp_field_{:?}{}", stack.groupby, i))
             .collect();
 
         let mut select_exprs = vec![col("__total")];

--- a/vegafusion-rt-datafusion/src/transform/stack.rs
+++ b/vegafusion-rt-datafusion/src/transform/stack.rs
@@ -12,11 +12,14 @@ use crate::transform::TransformTrait;
 use async_trait::async_trait;
 use datafusion::dataframe::DataFrame;
 use datafusion::physical_plan::aggregates;
-use datafusion_expr::{col, lit, when, BuiltInWindowFunction, Expr, WindowFunction};
-use std::ops::Sub;
+use datafusion_expr::logical_plan::JoinType;
+use datafusion_expr::{
+    abs, col, lit, max, sum, when, AggregateFunction, BuiltInWindowFunction, Expr, WindowFunction,
+};
+use std::ops::{Add, Div, Sub};
 use std::sync::Arc;
-use vegafusion_core::error::Result;
-use vegafusion_core::proto::gen::transforms::{SortOrder, Stack};
+use vegafusion_core::error::{Result, VegaFusionError};
+use vegafusion_core::proto::gen::transforms::{SortOrder, Stack, StackOffset};
 use vegafusion_core::task_graph::task_value::TaskValue;
 
 #[async_trait]
@@ -27,10 +30,19 @@ impl TransformTrait for Stack {
         _config: &CompilationConfig,
     ) -> Result<(Arc<DataFrame>, Vec<TaskValue>)> {
         // Assume offset is Zero until others are implemented
-
         let alias0 = self.alias_0.clone().expect("alias0 expected");
         let alias1 = self.alias_1.clone().expect("alias1 expected");
 
+        // Save off input columns
+        let input_fields: Vec<_> = dataframe
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.field().name().clone())
+            .collect();
+
+        // Build order by vector
+        // Order by row number last (and only if no explicit ordering provided)
         let mut order_by: Vec<_> = self
             .sort_fields
             .iter()
@@ -42,27 +54,13 @@ impl TransformTrait for Stack {
             })
             .collect();
 
-        // Save off input columns
-        let input_fields: Vec<_> = dataframe
-            .schema()
-            .fields()
-            .iter()
-            .map(|f| f.field().name().clone())
-            .collect();
+        order_by.push(Expr::Sort {
+            expr: Box::new(col("__row_number")),
+            asc: true,
+            nulls_first: true,
+        });
 
-        // Build first selection
-        let mut selection_0: Vec<_> = input_fields
-            .iter()
-            .filter_map(|field| {
-                if field == &alias0 || field == &alias1 {
-                    None
-                } else {
-                    Some(col(field))
-                }
-            })
-            .collect();
-
-        //  If no order by fields provided, use the row number
+        // Add row number column for sorting
         let row_number_expr = Expr::WindowFunction {
             fun: WindowFunction::BuiltInWindowFunction(BuiltInWindowFunction::RowNumber),
             args: Vec::new(),
@@ -71,76 +69,292 @@ impl TransformTrait for Stack {
             window_frame: None,
         }
         .alias("__row_number");
-        selection_0.push(col("__row_number"));
+
         let dataframe = dataframe.select(vec![Expr::Wildcard, row_number_expr])?;
 
-        // Order by row number last (and only if no explicit ordering provided)
-        order_by.push(Expr::Sort {
-            expr: Box::new(col("__row_number")),
-            asc: true,
-            nulls_first: true,
-        });
-
-        // Build groupby columns
-        let partition_by: Vec<_> = self.groupby.iter().map(|group| col(group)).collect();
-
-        // Build window expression
-        let fun = WindowFunction::AggregateFunction(aggregates::AggregateFunction::Sum);
-
-        // Cast field to number and replace with 0 when null
-        let numeric_field = to_numeric(col(&self.field), dataframe.schema())?;
-        let numeric_field =
-            when(col(&self.field).is_not_null(), numeric_field).otherwise(lit(0.0))?;
-
-        let window_expr = Expr::WindowFunction {
-            fun,
-            args: vec![numeric_field.clone()],
-            partition_by,
-            order_by,
-            window_frame: None,
-        }
-        .alias(&alias1);
-
-        selection_0.push(window_expr);
-
-        // For offset zero, we need to evaluate positive and negative field values separately,
-        // then union the results. This is required to make sure stacks do not overlap. Negative
-        // values stack in the negative direction and positive values stack in the positive
-        // direction.
-        let dataframe_pos = dataframe.filter(numeric_field.clone().gt_eq(lit(0.0)))?;
-        let dataframe_pos = dataframe_pos.select(selection_0.clone())?;
-
-        let dataframe_neg = dataframe.filter(numeric_field.clone().lt(lit(0.0)))?;
-        let dataframe_neg = dataframe_neg.select(selection_0.clone())?;
-
-        let dataframe = dataframe_pos.union(dataframe_neg)?;
-
-        // Restore original order
-        let dataframe = dataframe.sort(vec![Expr::Sort {
-            expr: Box::new(col("__row_number")),
-            asc: true,
-            nulls_first: false,
-        }])?;
-
-        // Build selection_1
-        let mut selection_1: Vec<_> = input_fields
-            .iter()
-            .filter_map(|field| {
-                if field == &alias0 || field == &alias1 {
-                    None
-                } else {
-                    Some(col(field))
-                }
-            })
-            .collect();
-
-        // Now compute alias1 column by adding numeric field to alias0
-        let alias0_col = col(&alias1).sub(numeric_field).alias(&alias0);
-        selection_1.push(alias0_col);
-        selection_1.push(col(&alias1));
-
-        let dataframe = dataframe.select(selection_1.clone())?;
+        // Process according to offset
+        let offset = StackOffset::from_i32(self.offset).expect("Failed to convert stack offset");
+        let dataframe = match offset {
+            StackOffset::Zero => eval_zero_offset(
+                &self,
+                dataframe,
+                input_fields.as_slice(),
+                &alias0,
+                &alias1,
+                order_by.as_slice(),
+            )?,
+            StackOffset::Normalize => eval_normalize_center_offset(
+                &self,
+                dataframe,
+                input_fields.as_slice(),
+                &alias0,
+                &alias1,
+                order_by.as_slice(),
+                &offset,
+            )?,
+            StackOffset::Center => eval_normalize_center_offset(
+                &self,
+                dataframe,
+                input_fields.as_slice(),
+                &alias0,
+                &alias1,
+                order_by.as_slice(),
+                &offset,
+            )?,
+        };
 
         Ok((dataframe, Default::default()))
     }
+}
+
+fn eval_normalize_center_offset(
+    stack: &Stack,
+    dataframe: Arc<DataFrame>,
+    input_fields: &[String],
+    alias0: &str,
+    alias1: &str,
+    order_by: &[Expr],
+    offset: &StackOffset,
+) -> Result<Arc<DataFrame>> {
+    // Build first selection
+    let mut selection_0: Vec<_> = input_fields
+        .iter()
+        .filter_map(|field| {
+            if field == &alias0 || field == &alias1 {
+                None
+            } else {
+                Some(col(field))
+            }
+        })
+        .collect();
+    selection_0.push(col("__row_number"));
+
+    // Build groupby columns
+    let partition_by: Vec<_> = stack.groupby.iter().map(|group| col(group)).collect();
+
+    // Build a dataframe that holds the sum of each partition
+
+    // Build window expression
+    let fun = WindowFunction::AggregateFunction(aggregates::AggregateFunction::Sum);
+
+    // Cast field to number, replace with 0 when null, take absolute value
+    let numeric_field = to_numeric(col(&stack.field), dataframe.schema())?;
+    let numeric_field = when(col(&stack.field).is_not_null(), numeric_field).otherwise(lit(0.0))?;
+    let numeric_field = abs(numeric_field);
+
+    let total_agg = Expr::AggregateFunction {
+        fun: AggregateFunction::Sum,
+        args: vec![numeric_field.clone()],
+        distinct: false,
+    }
+    .alias("__total");
+
+    let dataframe = if partition_by.is_empty() {
+        let total_dataframe = dataframe.aggregate(partition_by.clone(), vec![total_agg])?;
+        let total_dataframe =
+            total_dataframe.select(vec![Expr::Wildcard, lit(true).alias("__unit_lhs")])?;
+        let mut dataframe =
+            dataframe.select(vec![Expr::Wildcard, lit(true).alias("__unit_rhs")])?;
+
+        dataframe.join(
+            total_dataframe,
+            JoinType::Full,
+            vec!["__unit_lhs"].as_slice(),
+            vec!["__unit_rhs"].as_slice(),
+            None,
+        )?
+    } else {
+        let total_dataframe = dataframe.aggregate(partition_by.clone(), vec![total_agg])?;
+
+        // Rename group cols prior to join
+        let groupby_aliases: Vec<String> = partition_by
+            .iter()
+            .enumerate()
+            .map(|(i, _a)| format!("grp_field_{}", i))
+            .collect();
+
+        let mut select_exprs = vec![col("__total")];
+        select_exprs.extend(
+            partition_by
+                .clone()
+                .into_iter()
+                .zip(&groupby_aliases)
+                .map(|(n, alias)| n.alias(alias)),
+        );
+        let total_dataframe = total_dataframe.select(select_exprs)?;
+
+        let left_cols: Vec<_> = stack.groupby.iter().map(|name| name.as_str()).collect();
+        let right_cols: Vec<_> = groupby_aliases.iter().map(|name| name.as_str()).collect();
+        dataframe.join(
+            total_dataframe,
+            JoinType::Inner,
+            left_cols.as_slice(),
+            right_cols.as_slice(),
+            None,
+        )?
+    };
+
+    // Build window function
+    let window_expr = Expr::WindowFunction {
+        fun,
+        args: vec![numeric_field.clone()],
+        partition_by,
+        order_by: Vec::from(order_by),
+        window_frame: None,
+    }
+    .alias(&alias1);
+
+    selection_0.push(window_expr);
+    selection_0.push(col("__total"));
+
+    // Perform selection to add new field value
+    let dataframe = dataframe.select(selection_0.clone())?;
+
+    // Restore original order
+    let dataframe = dataframe.sort(vec![Expr::Sort {
+        expr: Box::new(col("__row_number")),
+        asc: true,
+        nulls_first: false,
+    }])?;
+
+    // Build selection_1
+    let mut selection_1: Vec<_> = input_fields
+        .iter()
+        .filter_map(|field| {
+            if field == alias0 || field == alias1 {
+                None
+            } else {
+                Some(col(field))
+            }
+        })
+        .collect();
+
+    // Now compute alias1 column by adding numeric field to alias0
+    let dataframe = match offset {
+        StackOffset::Center => {
+            // Center bars between 0 and the max total length bar
+            let max_total = max(col("__total")).alias("__max_total");
+            let max_total_dataframe = dataframe
+                .aggregate(vec![lit(true)], vec![max_total])?
+                .select(vec![Expr::Wildcard, lit(true).alias("__max_unit_rhs")])?;
+
+            let dataframe = dataframe
+                .select(vec![Expr::Wildcard, lit(true).alias("__max_unit_lhs")])?
+                .join(
+                    max_total_dataframe,
+                    JoinType::Inner,
+                    vec!["__max_unit_lhs"].as_slice(),
+                    vec!["__max_unit_rhs"].as_slice(),
+                    None,
+                )?;
+
+            let first = col("__max_total").sub(col("__total")).div(lit(2.0));
+            let alias1_col = col(&alias1).add(first).alias(alias1);
+            let alias0_col = alias1_col.clone().sub(numeric_field).alias(&alias0);
+            selection_1.push(alias0_col);
+            selection_1.push(alias1_col);
+
+            println!("{:#?}", dataframe.schema());
+
+            dataframe
+        }
+        StackOffset::Normalize => {
+            let alias0_col = col(&alias1)
+                .sub(numeric_field)
+                .div(col("__total"))
+                .alias(&alias0);
+            selection_1.push(alias0_col);
+
+            let alias1_col = col(&alias1).div(col("__total")).alias(&alias1);
+            selection_1.push(alias1_col);
+
+            dataframe
+        }
+        _ => return Err(VegaFusionError::internal("Unexpected stack offset")),
+    };
+
+    let dataframe = dataframe.select(selection_1.clone())?;
+    Ok(dataframe)
+}
+
+fn eval_zero_offset(
+    stack: &Stack,
+    dataframe: Arc<DataFrame>,
+    input_fields: &[String],
+    alias0: &str,
+    alias1: &str,
+    order_by: &[Expr],
+) -> Result<Arc<DataFrame>> {
+    // Build first selection
+    let mut selection_0: Vec<_> = input_fields
+        .iter()
+        .filter_map(|field| {
+            if field == &alias0 || field == &alias1 {
+                None
+            } else {
+                Some(col(field))
+            }
+        })
+        .collect();
+    selection_0.push(col("__row_number"));
+
+    // Build groupby columns
+    let partition_by: Vec<_> = stack.groupby.iter().map(|group| col(group)).collect();
+
+    // Build window expression
+    let fun = WindowFunction::AggregateFunction(aggregates::AggregateFunction::Sum);
+
+    // Cast field to number and replace with 0 when null
+    let numeric_field = to_numeric(col(&stack.field), dataframe.schema())?;
+    let numeric_field = when(col(&stack.field).is_not_null(), numeric_field).otherwise(lit(0.0))?;
+
+    let window_expr = Expr::WindowFunction {
+        fun,
+        args: vec![numeric_field.clone()],
+        partition_by,
+        order_by: Vec::from(order_by),
+        window_frame: None,
+    }
+    .alias(&alias1);
+
+    selection_0.push(window_expr);
+
+    // For offset zero, we need to evaluate positive and negative field values separately,
+    // then union the results. This is required to make sure stacks do not overlap. Negative
+    // values stack in the negative direction and positive values stack in the positive
+    // direction.
+    let dataframe_pos = dataframe.filter(numeric_field.clone().gt_eq(lit(0.0)))?;
+    let dataframe_pos = dataframe_pos.select(selection_0.clone())?;
+
+    let dataframe_neg = dataframe.filter(numeric_field.clone().lt(lit(0.0)))?;
+    let dataframe_neg = dataframe_neg.select(selection_0.clone())?;
+
+    let dataframe = dataframe_pos.union(dataframe_neg)?;
+
+    // Restore original order
+    let dataframe = dataframe.sort(vec![Expr::Sort {
+        expr: Box::new(col("__row_number")),
+        asc: true,
+        nulls_first: false,
+    }])?;
+
+    // Build selection_1
+    let mut selection_1: Vec<_> = input_fields
+        .iter()
+        .filter_map(|field| {
+            if field == alias0 || field == alias1 {
+                None
+            } else {
+                Some(col(field))
+            }
+        })
+        .collect();
+
+    // Now compute alias1 column by adding numeric field to alias0
+    let alias0_col = col(&alias1).sub(numeric_field).alias(&alias0);
+    selection_1.push(alias0_col);
+    selection_1.push(col(&alias1));
+
+    let dataframe = dataframe.select(selection_1.clone())?;
+    Ok(dataframe)
 }

--- a/vegafusion-rt-datafusion/src/transform/stack.rs
+++ b/vegafusion-rt-datafusion/src/transform/stack.rs
@@ -120,7 +120,7 @@ fn eval_normalize_center_offset(
     let mut selection_0: Vec<_> = input_fields
         .iter()
         .filter_map(|field| {
-            if field == &alias0 || field == &alias1 {
+            if field == alias0 || field == alias1 {
                 None
             } else {
                 Some(col(field))
@@ -288,7 +288,7 @@ fn eval_zero_offset(
     let mut selection_0: Vec<_> = input_fields
         .iter()
         .filter_map(|field| {
-            if field == &alias0 || field == &alias1 {
+            if field == alias0 || field == alias1 {
                 None
             } else {
                 Some(col(field))

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_normalize.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_normalize.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/rect_mosaic_labelled.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/rect_mosaic_labelled.comm_plan.json
@@ -2,7 +2,19 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "data_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_1",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_1_opacity_domain_Cylinders",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_2",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/rect_mosaic_simple.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/rect_mosaic_simple.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_Origin",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_opacity_domain_Cylinders",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_normalized_labeled.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_normalized_labeled.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "data_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_1",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_1_color_domain_gender",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_normalize.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_normalize.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_population_transform.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_population_transform.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/test_transform_stack.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_stack.rs
@@ -32,7 +32,9 @@ mod test_stack {
     #[rstest(
         offset,
         case(None),
-        case(Some(StackOffsetSpec::Zero))
+        case(Some(StackOffsetSpec::Zero)),
+        case(Some(StackOffsetSpec::Normalize)),
+        case(Some(StackOffsetSpec::Center)),
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");
@@ -45,6 +47,8 @@ mod test_stack {
             offset,
             extra: Default::default(),
         };
+
+        println!("{}", serde_json::to_string_pretty(&stack_spec).unwrap());
 
         let transform_specs = vec![TransformSpec::Stack(stack_spec)];
 
@@ -75,7 +79,9 @@ mod test_stack_with_group {
     #[rstest(
         offset,
         case(None),
-        case(Some(StackOffsetSpec::Zero))
+        case(Some(StackOffsetSpec::Zero)),
+        case(Some(StackOffsetSpec::Normalize)),
+        case(Some(StackOffsetSpec::Center)),
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");
@@ -118,7 +124,9 @@ mod test_stack_with_group_sort {
     #[rstest(
         offset,
         case(None),
-        case(Some(StackOffsetSpec::Zero))
+        case(Some(StackOffsetSpec::Zero)),
+        case(Some(StackOffsetSpec::Normalize)),
+        case(Some(StackOffsetSpec::Center)),
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");
@@ -170,7 +178,9 @@ mod test_stack_with_group_sort_negative {
     #[rstest(
         offset,
         case(None),
-        case(Some(StackOffsetSpec::Zero))
+        case(Some(StackOffsetSpec::Zero)),
+        case(Some(StackOffsetSpec::Normalize)),
+        case(Some(StackOffsetSpec::Center)),
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");

--- a/vegafusion-rt-datafusion/tests/test_transform_stack.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_stack.rs
@@ -21,146 +21,203 @@ use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_core::spec::values::{
     CompareSpec, Field, SortOrderOrList, SortOrderSpec, StringOrStringList,
 };
+use rstest::rstest;
 
-#[test]
-fn test_stack() {
-    let dataset = vega_json_dataset("penguins");
 
-    let stack_spec = StackTransformSpec {
-        field: Field::String("Body Mass (g)".to_string()),
-        groupby: None,
-        sort: None,
-        as_: None,
-        offset: None,
-        extra: Default::default(),
-    };
+#[cfg(test)]
+mod test_stack {
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
+    use super::*;
 
-    let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+    #[rstest(
+        offset,
+        case(None),
+        case(Some(StackOffsetSpec::Zero))
+    )]
+    fn test(offset: Option<StackOffsetSpec>) {
+        let dataset = vega_json_dataset("penguins");
 
-    let comp_config = Default::default();
-    let eq_config = TablesEqualConfig {
-        row_order: true,
-        ..Default::default()
-    };
+        let stack_spec = StackTransformSpec {
+            field: Field::String("Body Mass (g)".to_string()),
+            groupby: None,
+            sort: None,
+            as_: None,
+            offset,
+            extra: Default::default(),
+        };
 
-    check_transform_evaluation(
-        &dataset,
-        transform_specs.as_slice(),
-        &comp_config,
-        &eq_config,
-    );
+        let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
 }
 
-#[test]
-fn test_stack_with_group() {
-    let dataset = vega_json_dataset("penguins");
 
-    let stack_spec = StackTransformSpec {
-        field: Field::String("Body Mass (g)".to_string()),
-        groupby: Some(vec![Field::String("Species".to_string())]),
-        sort: None,
-        as_: None,
-        offset: None,
-        extra: Default::default(),
-    };
+#[cfg(test)]
+mod test_stack_with_group {
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
+    use super::*;
 
-    let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+    #[rstest(
+        offset,
+        case(None),
+        case(Some(StackOffsetSpec::Zero))
+    )]
+    fn test(offset: Option<StackOffsetSpec>) {
+        let dataset = vega_json_dataset("penguins");
 
-    let comp_config = Default::default();
-    let eq_config = TablesEqualConfig {
-        row_order: true,
-        ..Default::default()
-    };
+        let stack_spec = StackTransformSpec {
+            field: Field::String("Body Mass (g)".to_string()),
+            groupby: Some(vec![Field::String("Species".to_string())]),
+            sort: None,
+            as_: None,
+            offset,
+            extra: Default::default(),
+        };
 
-    check_transform_evaluation(
-        &dataset,
-        transform_specs.as_slice(),
-        &comp_config,
-        &eq_config,
-    );
+        let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
 }
 
-#[test]
-fn test_stack_with_group_sort() {
-    let dataset = vega_json_dataset("penguins");
 
-    let stack_spec = StackTransformSpec {
-        field: Field::String("Body Mass (g)".to_string()),
-        groupby: Some(vec![Field::String("Species".to_string())]),
-        sort: Some(CompareSpec {
-            field: StringOrStringList::StringList(vec![
-                "Sex".to_string(),
-                "Flipper Length (mm)".to_string(),
-            ]),
-            order: Some(SortOrderOrList::SortOrderList(vec![
-                SortOrderSpec::Ascending,
-                SortOrderSpec::Descending,
-            ])),
-        }),
-        as_: Some(vec!["foo".to_string(), "bar".to_string()]),
-        offset: None,
-        extra: Default::default(),
-    };
+#[cfg(test)]
+mod test_stack_with_group_sort {
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
+    use super::*;
 
-    let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+    #[rstest(
+        offset,
+        case(None),
+        case(Some(StackOffsetSpec::Zero))
+    )]
+    fn test(offset: Option<StackOffsetSpec>) {
+        let dataset = vega_json_dataset("penguins");
 
-    let comp_config = Default::default();
-    let eq_config = TablesEqualConfig {
-        row_order: true,
-        ..Default::default()
-    };
+        let stack_spec = StackTransformSpec {
+            field: Field::String("Body Mass (g)".to_string()),
+            groupby: Some(vec![Field::String("Species".to_string())]),
+            sort: Some(CompareSpec {
+                field: StringOrStringList::StringList(vec![
+                    "Sex".to_string(),
+                    "Flipper Length (mm)".to_string(),
+                ]),
+                order: Some(SortOrderOrList::SortOrderList(vec![
+                    SortOrderSpec::Ascending,
+                    SortOrderSpec::Descending,
+                ])),
+            }),
+            as_: Some(vec!["foo".to_string(), "bar".to_string()]),
+            offset,
+            extra: Default::default(),
+        };
 
-    check_transform_evaluation(
-        &dataset,
-        transform_specs.as_slice(),
-        &comp_config,
-        &eq_config,
-    );
+        let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
 }
 
-#[test]
-fn test_stack_with_group_sort_negative() {
-    let dataset = vega_json_dataset("penguins");
 
-    let formula_spec = FormulaTransformSpec {
-        expr: "(datum['Body Mass (g)'] || 0) - 4000".to_string(),
-        as_: "Body Mass (g)".to_string(),
-        extra: Default::default(),
-    };
+#[cfg(test)]
+mod test_stack_with_group_sort_negative {
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
+    use super::*;
 
-    let stack_spec = StackTransformSpec {
-        field: Field::String("Body Mass (g)".to_string()),
-        groupby: Some(vec![Field::String("Species".to_string())]),
-        sort: Some(CompareSpec {
-            field: StringOrStringList::StringList(vec![
-                "Sex".to_string(),
-                "Flipper Length (mm)".to_string(),
-            ]),
-            order: Some(SortOrderOrList::SortOrderList(vec![
-                SortOrderSpec::Ascending,
-                SortOrderSpec::Descending,
-            ])),
-        }),
-        as_: Some(vec!["foo".to_string(), "bar".to_string()]),
-        offset: None,
-        extra: Default::default(),
-    };
+    #[rstest(
+        offset,
+        case(None),
+        case(Some(StackOffsetSpec::Zero))
+    )]
+    fn test(offset: Option<StackOffsetSpec>) {
+        let dataset = vega_json_dataset("penguins");
 
-    let transform_specs = vec![
-        TransformSpec::Formula(formula_spec),
-        TransformSpec::Stack(stack_spec),
-    ];
+        let formula_spec = FormulaTransformSpec {
+            expr: "(datum['Body Mass (g)'] || 0) - 4000".to_string(),
+            as_: "Body Mass (g)".to_string(),
+            extra: Default::default(),
+        };
 
-    let comp_config = Default::default();
-    let eq_config = TablesEqualConfig {
-        row_order: true,
-        ..Default::default()
-    };
+        let stack_spec = StackTransformSpec {
+            field: Field::String("Body Mass (g)".to_string()),
+            groupby: Some(vec![Field::String("Species".to_string())]),
+            sort: Some(CompareSpec {
+                field: StringOrStringList::StringList(vec![
+                    "Sex".to_string(),
+                    "Flipper Length (mm)".to_string(),
+                ]),
+                order: Some(SortOrderOrList::SortOrderList(vec![
+                    SortOrderSpec::Ascending,
+                    SortOrderSpec::Descending,
+                ])),
+            }),
+            as_: Some(vec!["foo".to_string(), "bar".to_string()]),
+            offset,
+            extra: Default::default(),
+        };
 
-    check_transform_evaluation(
-        &dataset,
-        transform_specs.as_slice(),
-        &comp_config,
-        &eq_config,
-    );
+        let transform_specs = vec![
+            TransformSpec::Formula(formula_spec),
+            TransformSpec::Stack(stack_spec),
+        ];
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
 }

--- a/vegafusion-rt-datafusion/tests/test_transform_stack.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_stack.rs
@@ -16,25 +16,24 @@ use util::datasets::vega_json_dataset;
 use util::equality::TablesEqualConfig;
 use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
 
+use rstest::rstest;
 use vegafusion_core::spec::transform::stack::StackTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_core::spec::values::{
     CompareSpec, Field, SortOrderOrList, SortOrderSpec, StringOrStringList,
 };
-use rstest::rstest;
-
 
 #[cfg(test)]
 mod test_stack {
-    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
     use super::*;
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
 
     #[rstest(
         offset,
         case(None),
         case(Some(StackOffsetSpec::Zero)),
         case(Some(StackOffsetSpec::Normalize)),
-        case(Some(StackOffsetSpec::Center)),
+        case(Some(StackOffsetSpec::Center))
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");
@@ -70,18 +69,17 @@ mod test_stack {
     fn test_marker() {} // Help IDE detect test module
 }
 
-
 #[cfg(test)]
 mod test_stack_with_group {
-    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
     use super::*;
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
 
     #[rstest(
         offset,
         case(None),
         case(Some(StackOffsetSpec::Zero)),
         case(Some(StackOffsetSpec::Normalize)),
-        case(Some(StackOffsetSpec::Center)),
+        case(Some(StackOffsetSpec::Center))
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");
@@ -115,18 +113,17 @@ mod test_stack_with_group {
     fn test_marker() {} // Help IDE detect test module
 }
 
-
 #[cfg(test)]
 mod test_stack_with_group_sort {
-    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
     use super::*;
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
 
     #[rstest(
         offset,
         case(None),
         case(Some(StackOffsetSpec::Zero)),
         case(Some(StackOffsetSpec::Normalize)),
-        case(Some(StackOffsetSpec::Center)),
+        case(Some(StackOffsetSpec::Center))
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");
@@ -169,18 +166,17 @@ mod test_stack_with_group_sort {
     fn test_marker() {} // Help IDE detect test module
 }
 
-
 #[cfg(test)]
 mod test_stack_with_group_sort_negative {
-    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
     use super::*;
+    use vegafusion_core::spec::transform::stack::StackOffsetSpec;
 
     #[rstest(
         offset,
         case(None),
         case(Some(StackOffsetSpec::Zero)),
         case(Some(StackOffsetSpec::Normalize)),
-        case(Some(StackOffsetSpec::Center)),
+        case(Some(StackOffsetSpec::Center))
     )]
     fn test(offset: Option<StackOffsetSpec>) {
         let dataset = vega_json_dataset("penguins");

--- a/vegafusion-rt-datafusion/tests/test_transform_stack.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_stack.rs
@@ -14,6 +14,7 @@ mod util;
 use util::check::check_transform_evaluation;
 use util::datasets::vega_json_dataset;
 use util::equality::TablesEqualConfig;
+use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
 
 use vegafusion_core::spec::transform::stack::StackTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
@@ -102,6 +103,53 @@ fn test_stack_with_group_sort() {
     };
 
     let transform_specs = vec![TransformSpec::Stack(stack_spec)];
+
+    let comp_config = Default::default();
+    let eq_config = TablesEqualConfig {
+        row_order: true,
+        ..Default::default()
+    };
+
+    check_transform_evaluation(
+        &dataset,
+        transform_specs.as_slice(),
+        &comp_config,
+        &eq_config,
+    );
+}
+
+#[test]
+fn test_stack_with_group_sort_negative() {
+    let dataset = vega_json_dataset("penguins");
+
+    let formula_spec = FormulaTransformSpec {
+        expr: "(datum['Body Mass (g)'] || 0) - 4000".to_string(),
+        as_: "Body Mass (g)".to_string(),
+        extra: Default::default(),
+    };
+
+    let stack_spec = StackTransformSpec {
+        field: Field::String("Body Mass (g)".to_string()),
+        groupby: Some(vec![Field::String("Species".to_string())]),
+        sort: Some(CompareSpec {
+            field: StringOrStringList::StringList(vec![
+                "Sex".to_string(),
+                "Flipper Length (mm)".to_string(),
+            ]),
+            order: Some(SortOrderOrList::SortOrderList(vec![
+                SortOrderSpec::Ascending,
+                SortOrderSpec::Descending,
+            ])),
+        }),
+        as_: Some(vec!["foo".to_string(), "bar".to_string()]),
+        offset: None,
+        extra: Default::default(),
+    };
+
+    let transform_specs = vec![
+        TransformSpec::Formula(formula_spec),
+        TransformSpec::Stack(stack_spec),
+    ];
 
     let comp_config = Default::default();
     let eq_config = TablesEqualConfig {


### PR DESCRIPTION
This PR is a follow-on to https://github.com/vegafusion/vegafusion/pull/137 that adds support for performing the `stack` transform with `offset` values of `"center"` and `"normalize"`. 