### PR TITLE
Fix Vega-Lite color as datum issue by updating json parsing precedence

### DIFF
--- a/vegafusion-core/src/spec/scale.rs
+++ b/vegafusion-core/src/spec/scale.rs
@@ -74,13 +74,13 @@ impl ScaleTypeSpec {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ScaleDomainSpec {
+    Array(Vec<ScaleArrayElementSpec>),
     FieldReference(ScaleDataReferenceSpec),
     FieldsReference(ScaleDataReferencesSpec),
     FieldsVecStrings(ScaleVecStringsSpec),
     FieldsStrings(ScaleStringsSpec),
     FieldsSignals(ScaleSignalsSpec),
     Signal(SignalExpressionSpec),
-    Array(Vec<ScaleArrayElementSpec>),
     Value(Value),
 }
 

--- a/vegafusion-rt-datafusion/tests/specs/custom/datum_color.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/datum_color.comm_plan.json
@@ -1,0 +1,4 @@
+{
+  "server_to_client": [],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/datum_color.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/datum_color.vg.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 200,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {
+      "name": "df",
+      "values": [
+        {"x": 1, "y": 1, "y2": 2},
+        {"x": 2, "y": 2, "y2": 3},
+        {"x": 3, "y": 3, "y2": 4}
+      ],
+      "format": {}
+    },
+    {
+      "name": "data_0",
+      "source": "df",
+      "transform": [
+        {"type": "formula", "expr": "toNumber(datum[\"x\"])", "as": "x"}
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "layer_0_marks",
+      "type": "line",
+      "clip": true,
+      "style": ["line"],
+      "sort": {"field": "datum[\"x\"]"},
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "tooltip": {
+            "signal": "{\"x\": format(datum[\"x\"], \"\"), \"y\": format(datum[\"y\"], \"\")}"
+          },
+          "stroke": {"scale": "color", "value": "Line 1"},
+          "description": {
+            "signal": "\"x: \" + (format(datum[\"x\"], \"\")) + \"; y: \" + (format(datum[\"y\"], \"\"))"
+          },
+          "x": {"scale": "x", "field": "x"},
+          "y": {"scale": "y", "field": "y"},
+          "defined": {
+            "signal": "isValid(datum[\"x\"]) && isFinite(+datum[\"x\"]) && isValid(datum[\"y\"]) && isFinite(+datum[\"y\"])"
+          }
+        }
+      }
+    },
+    {
+      "name": "layer_1_marks",
+      "type": "line",
+      "clip": true,
+      "style": ["line"],
+      "sort": {"field": "datum[\"x\"]"},
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "tooltip": {
+            "signal": "{\"x\": format(datum[\"x\"], \"\"), \"y2\": format(datum[\"y2\"], \"\")}"
+          },
+          "stroke": {"value": "#4c78a8"},
+          "description": {
+            "signal": "\"x: \" + (format(datum[\"x\"], \"\")) + \"; y2: \" + (format(datum[\"y2\"], \"\"))"
+          },
+          "x": {"scale": "x", "field": "x"},
+          "y": {"scale": "y", "field": "y2"},
+          "defined": {
+            "signal": "isValid(datum[\"x\"]) && isFinite(+datum[\"x\"]) && isValid(datum[\"y2\"]) && isFinite(+datum[\"y2\"])"
+          }
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": {"data": "data_0", "field": "x"},
+      "range": [0, {"signal": "width"}],
+      "nice": true,
+      "zero": false
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "data_0", "fields": ["y", "y2"]},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": ["Line 1"],
+      "range": "category"
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "gridScale": "y",
+      "grid": true,
+      "tickCount": {"signal": "ceil(width/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "gridScale": "x",
+      "grid": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "x",
+      "labelFlush": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(width/40)"},
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "y, y2",
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ],
+  "legends": [{"stroke": "color", "symbolType": "stroke"}]
+}

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -117,7 +117,8 @@ mod test_custom_specs {
         case("custom/movies_agg_parameterize", 0.001),
         case("custom/escaped_column_name1", 0.001),
         case("custom/layered_movies", 0.001),
-        case("custom/shipping_mixed_scales", 0.001)
+        case("custom/shipping_mixed_scales", 0.001),
+        case("custom/datum_color", 0.001)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64) {
         println!("spec_name: {}", spec_name);
@@ -1281,6 +1282,7 @@ async fn check_pre_transform_spec_from_files(spec_name: &str, tolerance: f64) {
 
     // Load spec
     let full_spec = load_spec(spec_name);
+    println!("{:#?}", full_spec);
 
     let vegajs_runtime = vegajs_runtime();
 


### PR DESCRIPTION
Example Vega-Lite specification ([Open in editor](https://vega.github.io/editor/#/url/vega-lite/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykBaADZ04JAKyUAVhDYA7EABoQgpAE84AJzQBtUABMkmFKlCykCOGhB6AZopDEkghnAg7QADzQBGJap9+AExogQC+Cp4hflEgqsGoAMzhkYnRqbHxACyhALrhIMgaANZooJiqOJbowrKWSlDCOGiYGi5KmGxsgpg0TagtLvlwslBsejSyZKUgXiYgNjRwgnpWXu0VVSAAjgxIsj1GPaQg+f5zC0sr6P7rlVY7eweGNMf5o4JsWnMGmAwIVgAZCZwAAE3hOoWS1kMxlM5k2tnsjmcrncMwCsQxcRCUNmgTS+IyaCSEXR6TOCSCaGyeSUhRKcw6XR6fQGcFumxqdRADV6zVacCGIzGEymc1moAuy1W9nKd3QD32dGerzSksW0uuwQ5912SsOL0skNySg0ri6xzm0CcVWAxqAA))

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "layer": [
    {
      "data": {
        "name": "df",
        "values": [
          {"x": 1, "y": 1, "y2": 2},
          {"x": 2, "y": 2, "y2": 3},
          {"x": 3, "y": 3, "y2": 4}
        ]
      },
      "mark": {"type": "line", "clip": true, "tooltip": true},
      "encoding": {
        "x": {"field": "x", "type": "quantitative"},
        "y": {"field": "y", "type": "quantitative"},
        "color": {"datum": "Line 1"}
      }
    },
    {
      "data": {
        "name": "df",
        "values": [
          {"x": 1, "y": 1, "y2": 2},
          {"x": 2, "y": 2, "y2": 3},
          {"x": 3, "y": 3, "y2": 4}
        ]
      },
      "mark": {"tooltip": true, "type": "line", "clip": true},
      "encoding": {
        "x": {"field": "x", "type": "quantitative"},
        "y": {"field": "y2", "type": "quantitative"}
      }
    }
  ],
  "resolve": {"scale": {}}
}
```

Resulted in error:
```
PanicException: called `Result::unwrap()` on an `Err` value: ParseError("Unexpected token '1'", ErrorContext { contexts: ["Failed to parse form starting at position 5 in expression: Line 1"] }
```

The issue is while parsing the scale produced in the resulting Vega specification:

```json
    {
      "name": "color",
      "type": "ordinal",
      "domain": ["Line 1"],
      "range": "category"
    }
```

For some reason, serde was parsing `["Line 1"]` as though it were `{"signal": "Line 1"}`.  I'm not clear yet on why this was happening, but as a work-around this PR changes the parsing precedence of `domain` to include arrays as the highest precedence.


