### PR TITLE
Add initial impute transform support

### DIFF
--- a/vegafusion-core/src/proto/prost_gen/transforms.rs
+++ b/vegafusion-core/src/proto/prost_gen/transforms.rs
@@ -177,10 +177,24 @@ pub struct Stack {
     #[prost(string, optional, tag="7")]
     pub alias_1: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// Impute
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Impute {
+    #[prost(string, tag="1")]
+    pub field: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(enumeration="ImputeMethod", tag="3")]
+    pub method: i32,
+    #[prost(string, repeated, tag="4")]
+    pub groupby: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="5")]
+    pub value_json: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// Top-level transform
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transform {
-    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
+    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12")]
     pub transform_kind: ::core::option::Option<transform::TransformKind>,
 }
 /// Nested message and enum types in `Transform`.
@@ -209,6 +223,8 @@ pub mod transform {
         Project(super::Project),
         #[prost(message, tag="11")]
         Stack(super::Stack),
+        #[prost(message, tag="12")]
+        Impute(super::Impute),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -294,4 +310,13 @@ pub enum StackOffset {
     Zero = 0,
     Center = 1,
     Normalize = 2,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ImputeMethod {
+    ImputeValue = 0,
+    ImputeMean = 1,
+    ImputeMedian = 2,
+    ImputeMax = 3,
+    ImputeMin = 4,
 }

--- a/vegafusion-core/src/proto/tonic_gen/transforms.rs
+++ b/vegafusion-core/src/proto/tonic_gen/transforms.rs
@@ -177,10 +177,24 @@ pub struct Stack {
     #[prost(string, optional, tag="7")]
     pub alias_1: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// Impute
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Impute {
+    #[prost(string, tag="1")]
+    pub field: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(enumeration="ImputeMethod", tag="3")]
+    pub method: i32,
+    #[prost(string, repeated, tag="4")]
+    pub groupby: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="5")]
+    pub value_json: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// Top-level transform
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transform {
-    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
+    #[prost(oneof="transform::TransformKind", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12")]
     pub transform_kind: ::core::option::Option<transform::TransformKind>,
 }
 /// Nested message and enum types in `Transform`.
@@ -209,6 +223,8 @@ pub mod transform {
         Project(super::Project),
         #[prost(message, tag="11")]
         Stack(super::Stack),
+        #[prost(message, tag="12")]
+        Impute(super::Impute),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -294,4 +310,13 @@ pub enum StackOffset {
     Zero = 0,
     Center = 1,
     Normalize = 2,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ImputeMethod {
+    ImputeValue = 0,
+    ImputeMean = 1,
+    ImputeMedian = 2,
+    ImputeMax = 3,
+    ImputeMin = 4,
 }

--- a/vegafusion-core/src/proto/transforms.proto
+++ b/vegafusion-core/src/proto/transforms.proto
@@ -206,6 +206,23 @@ enum StackOffset {
   Normalize = 2;
 }
 
+// Impute
+message Impute {
+  string field = 1;
+  string key = 2;
+  ImputeMethod method = 3;
+  repeated string groupby = 4;
+  optional string value_json = 5;
+}
+
+enum ImputeMethod {
+    ImputeValue = 0;
+    ImputeMean = 1;
+    ImputeMedian = 2;
+    ImputeMax = 3;
+    ImputeMin = 4;
+}
+
 // Top-level transform
 message Transform {
   oneof transform_kind {
@@ -220,6 +237,7 @@ message Transform {
     Window window = 9;
     Project project = 10;
     Stack stack = 11;
+    Impute impute = 12;
   }
 }
 

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -13,7 +13,7 @@ pub struct ImputeTransformSpec {
     pub key: Field,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub keyvals: Option<Vec<Value>>,
+    pub keyvals: Option<Value>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<ImputeMethodSpec>,
@@ -32,6 +32,10 @@ impl ImputeTransformSpec {
     pub fn method(&self) -> ImputeMethodSpec {
         self.method.clone().unwrap_or(ImputeMethodSpec::Value)
     }
+
+    pub fn groupby(&self) -> Vec<Field> {
+        self.groupby.clone().unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -45,6 +49,15 @@ pub enum ImputeMethodSpec {
 }
 
 impl TransformSpecTrait for ImputeTransformSpec {
+    fn supported(&self) -> bool {
+        self.field.as_().is_none()
+            && self.key.as_().is_none()
+            && self.keyvals.is_none()
+            && self.method() == ImputeMethodSpec::Value
+            && self.groupby().len() <= 1
+            && self.value.is_some()
+    }
+
     fn transform_columns(
         &self,
         datum_var: &Option<ScopedVariable>,

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -1,0 +1,77 @@
+use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::proto::gen::expression::literal::Value;
+use crate::spec::transform::{TransformColumns, TransformSpecTrait};
+use crate::spec::values::Field;
+use crate::task_graph::graph::ScopedVariable;
+use crate::task_graph::scope::TaskScope;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImputeTransformSpec {
+    pub field: Field,
+    pub key: Field,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keyvals: Option<Vec<Value>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<ImputeMethodSpec>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groupby: Option<Vec<Field>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl ImputeTransformSpec {
+    pub fn method(&self) -> ImputeMethodSpec {
+        self.method.unwrap_or(ImputeMethodSpec::Value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ImputeMethodSpec {
+    Value,
+    Mean,
+    Median,
+    Max,
+    Min,
+}
+
+impl TransformSpecTrait for ImputeTransformSpec {
+    fn transform_columns(
+        &self,
+        datum_var: &Option<ScopedVariable>,
+        _usage_scope: &[u32],
+        _task_scope: &TaskScope,
+        _vl_selection_fields: &VlSelectionFields,
+    ) -> TransformColumns {
+        if let Some(datum_var) = datum_var {
+            // Init column usage with field
+            let mut col_usage = ColumnUsage::from(self.field.field().as_str());
+
+            // Add key
+            col_usage = col_usage.with_column(self.key.field().as_str());
+
+            // Add groupby usage
+            if let Some(groupby) = self.groupby.as_ref() {
+                let groupby: Vec<_> = groupby.iter().map(|field| field.field()).collect();
+                col_usage = col_usage.union(&ColumnUsage::from(groupby.as_slice()));
+            }
+
+            // Build produced (no columns are created by impute transform)
+            let produced = ColumnUsage::empty();
+
+            let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);
+            TransformColumns::PassThrough { usage, produced }
+        } else {
+            TransformColumns::Unknown
+        }
+    }
+}

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -1,10 +1,10 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
-use crate::proto::gen::expression::literal::Value;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::Field;
 use crate::task_graph::graph::ScopedVariable;
 use crate::task_graph::scope::TaskScope;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -30,7 +30,7 @@ pub struct ImputeTransformSpec {
 
 impl ImputeTransformSpec {
     pub fn method(&self) -> ImputeMethodSpec {
-        self.method.unwrap_or(ImputeMethodSpec::Value)
+        self.method.clone().unwrap_or(ImputeMethodSpec::Value)
     }
 }
 

--- a/vegafusion-core/src/spec/transform/mod.rs
+++ b/vegafusion-core/src/spec/transform/mod.rs
@@ -12,6 +12,7 @@ pub mod collect;
 pub mod extent;
 pub mod filter;
 pub mod formula;
+pub mod impute;
 pub mod joinaggregate;
 pub mod lookup;
 pub mod project;
@@ -29,6 +30,7 @@ use crate::spec::transform::aggregate::AggregateTransformSpec;
 use crate::spec::transform::bin::BinTransformSpec;
 use crate::spec::transform::collect::CollectTransformSpec;
 use crate::spec::transform::formula::FormulaTransformSpec;
+use crate::spec::transform::impute::ImputeTransformSpec;
 use crate::spec::transform::joinaggregate::JoinAggregateTransformSpec;
 use crate::spec::transform::lookup::LookupTransformSpec;
 use crate::spec::transform::project::ProjectTransformSpec;
@@ -56,7 +58,8 @@ pub enum TransformSpec {
     JoinAggregate(JoinAggregateTransformSpec),
     Window(WindowTransformSpec),
     Project(ProjectTransformSpec),
-    /**/ Stack(StackTransformSpec),
+    Stack(StackTransformSpec),
+    Impute(ImputeTransformSpec),
 
     // Unsupported
     CountPattern(CountpatternTransformSpec),
@@ -75,7 +78,6 @@ pub enum TransformSpec {
     Graticule(GraticuleTransformSpec),
     Heatmap(HeatmapTransformSpec),
     Identifier(IdentifierTransformSpec),
-    Impute(ImputeTransformSpec),
     IsoContour(IsocontourTransformSpec),
     Kde(KdeTransformSpec),
     Kde2d(Kde2dTransformSpec),
@@ -115,6 +117,7 @@ impl Deref for TransformSpec {
             TransformSpec::Timeunit(t) => t,
             TransformSpec::Project(t) => t,
             TransformSpec::Stack(t) => t,
+            TransformSpec::Impute(t) => t,
 
             // Supported for dependency determination, not implementation
             TransformSpec::Lookup(t) => t,
@@ -137,7 +140,6 @@ impl Deref for TransformSpec {
             TransformSpec::Graticule(t) => t,
             TransformSpec::Heatmap(t) => t,
             TransformSpec::Identifier(t) => t,
-            TransformSpec::Impute(t) => t,
             TransformSpec::IsoContour(t) => t,
             TransformSpec::JoinAggregate(t) => t,
             TransformSpec::Kde(t) => t,

--- a/vegafusion-core/src/spec/transform/unsupported.rs
+++ b/vegafusion-core/src/spec/transform/unsupported.rs
@@ -45,7 +45,6 @@ unsupported_transforms!(
     GraticuleTransformSpec,
     HeatmapTransformSpec,
     IdentifierTransformSpec,
-    ImputeTransformSpec,
     IsocontourTransformSpec,
     KdeTransformSpec,
     Kde2dTransformSpec,

--- a/vegafusion-core/src/transform/impute.rs
+++ b/vegafusion-core/src/transform/impute.rs
@@ -15,10 +15,10 @@ impl Impute {
         };
 
         // Extract field
-        let field = spec.field.field().clone();
+        let field = spec.field.field();
 
         // Extract key
-        let key = spec.key.field().clone();
+        let key = spec.key.field();
 
         // Extract groupby
         let groupby: Vec<_> = spec
@@ -30,11 +30,10 @@ impl Impute {
             .collect();
 
         // Extract Value
-        let value_json = if let Some(value) = &spec.value {
-            Some(serde_json::to_string(value).unwrap())
-        } else {
-            None
-        };
+        let value_json = spec
+            .value
+            .as_ref()
+            .map(|value| serde_json::to_string(value).unwrap());
 
         // keyvals not yet supported
 

--- a/vegafusion-core/src/transform/impute.rs
+++ b/vegafusion-core/src/transform/impute.rs
@@ -1,0 +1,51 @@
+use crate::error::Result;
+use crate::proto::gen::transforms::{Impute, ImputeMethod};
+use crate::spec::transform::impute::{ImputeMethodSpec, ImputeTransformSpec};
+use crate::transform::TransformDependencies;
+
+impl Impute {
+    pub fn try_new(spec: &ImputeTransformSpec) -> Result<Self> {
+        // Extract method
+        let method = match spec.method() {
+            ImputeMethodSpec::Value => ImputeMethod::ImputeValue,
+            ImputeMethodSpec::Mean => ImputeMethod::ImputeMean,
+            ImputeMethodSpec::Median => ImputeMethod::ImputeMedian,
+            ImputeMethodSpec::Max => ImputeMethod::ImputeMax,
+            ImputeMethodSpec::Min => ImputeMethod::ImputeMin,
+        };
+
+        // Extract field
+        let field = spec.field.field().clone();
+
+        // Extract key
+        let key = spec.key.field().clone();
+
+        // Extract groupby
+        let groupby: Vec<_> = spec
+            .groupby
+            .clone()
+            .unwrap_or_default()
+            .iter()
+            .map(|field| field.field())
+            .collect();
+
+        // Extract Value
+        let value_json = if let Some(value) = &spec.value {
+            Some(serde_json::to_string(value).unwrap())
+        } else {
+            None
+        };
+
+        // keyvals not yet supported
+
+        Ok(Impute {
+            field,
+            key,
+            method: method as i32,
+            groupby,
+            value_json,
+        })
+    }
+}
+
+impl TransformDependencies for Impute {}

--- a/vegafusion-core/src/transform/mod.rs
+++ b/vegafusion-core/src/transform/mod.rs
@@ -10,7 +10,7 @@ use crate::error::VegaFusionError;
 use crate::proto::gen::tasks::Variable;
 use crate::proto::gen::transforms::transform::TransformKind;
 use crate::proto::gen::transforms::{
-    Aggregate, Bin, Collect, Extent, Filter, Formula, Project, Stack, TimeUnit,
+    Aggregate, Bin, Collect, Extent, Filter, Formula, Impute, Project, Stack, TimeUnit,
 };
 use crate::proto::gen::transforms::{JoinAggregate, Transform, Window};
 use crate::spec::transform::TransformSpec;
@@ -23,6 +23,7 @@ pub mod collect;
 pub mod extent;
 pub mod filter;
 pub mod formula;
+pub mod impute;
 pub mod joinaggregate;
 pub mod pipeline;
 pub mod project;
@@ -48,6 +49,7 @@ impl TryFrom<&TransformSpec> for TransformKind {
             TransformSpec::Window(tx_spec) => Self::Window(Window::try_new(tx_spec)?),
             TransformSpec::Project(tx_spec) => Self::Project(Project::try_new(tx_spec)?),
             TransformSpec::Stack(tx_spec) => Self::Stack(Stack::try_new(tx_spec)?),
+            TransformSpec::Impute(tx_spec) => Self::Impute(Impute::try_new(tx_spec)?),
             _ => {
                 return Err(VegaFusionError::parse(&format!(
                     "Unsupported transform: {:?}",
@@ -82,6 +84,7 @@ impl TransformKind {
             TransformKind::Window(tx) => tx,
             TransformKind::Project(tx) => tx,
             TransformKind::Stack(tx) => tx,
+            TransformKind::Impute(tx) => tx,
         }
     }
 }

--- a/vegafusion-rt-datafusion/src/transform/impute.rs
+++ b/vegafusion-rt-datafusion/src/transform/impute.rs
@@ -16,7 +16,7 @@ impl TransformTrait for Impute {
     async fn eval(
         &self,
         dataframe: Arc<DataFrame>,
-        config: &CompilationConfig,
+        _config: &CompilationConfig,
     ) -> vegafusion_core::error::Result<(Arc<DataFrame>, Vec<TaskValue>)> {
         // Create ScalarValue used to fill in null values
         let value =
@@ -43,7 +43,7 @@ fn zero_groupby(
 ) -> Result<Arc<DataFrame>> {
     // Value replacement for field with no groupby fields specified is equivalent to replacing
     // null values of that column with the fill value
-    let mut select_columns: Vec<_> = dataframe
+    let select_columns: Vec<_> = dataframe
         .schema()
         .fields()
         .iter()

--- a/vegafusion-rt-datafusion/src/transform/impute.rs
+++ b/vegafusion-rt-datafusion/src/transform/impute.rs
@@ -1,0 +1,183 @@
+use crate::expression::compiler::config::CompilationConfig;
+use crate::transform::TransformTrait;
+use async_trait::async_trait;
+use datafusion::common::ScalarValue;
+use datafusion::dataframe::DataFrame;
+use datafusion_expr::logical_plan::JoinType;
+use datafusion_expr::{col, lit, when, BuiltInWindowFunction, Expr, WindowFunction};
+use std::sync::Arc;
+use vegafusion_core::data::scalar::ScalarValueHelpers;
+use vegafusion_core::error::{Result, VegaFusionError};
+use vegafusion_core::proto::gen::transforms::Impute;
+use vegafusion_core::task_graph::task_value::TaskValue;
+
+#[async_trait]
+impl TransformTrait for Impute {
+    async fn eval(
+        &self,
+        dataframe: Arc<DataFrame>,
+        config: &CompilationConfig,
+    ) -> vegafusion_core::error::Result<(Arc<DataFrame>, Vec<TaskValue>)> {
+        // Create ScalarValue used to fill in null values
+        let value =
+            ScalarValue::from_json(&serde_json::from_str(self.value_json.as_ref().unwrap())?)?;
+
+        let dataframe = match self.groupby.len() {
+            0 => zero_groupby(self, dataframe, value)?,
+            1 => single_groupby(self, dataframe, value)?,
+            _ => {
+                return Err(VegaFusionError::internal(
+                    "Expected zero or one groupby columns to impute",
+                ))
+            }
+        };
+
+        Ok((dataframe, Vec::new()))
+    }
+}
+
+fn zero_groupby(
+    tx: &Impute,
+    dataframe: Arc<DataFrame>,
+    value: ScalarValue,
+) -> Result<Arc<DataFrame>> {
+    // Value replacement for field with no groupby fields specified is equivalent to replacing
+    // null values of that column with the fill value
+    let mut select_columns: Vec<_> = dataframe
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| {
+            let col_name = field.name();
+            if col_name == &tx.field {
+                when(col(&tx.field).is_not_null(), col(&tx.field))
+                    .otherwise(lit(value.clone()))
+                    .unwrap()
+                    .alias(&tx.field)
+            } else {
+                col(col_name)
+            }
+        })
+        .collect();
+
+    Ok(dataframe.select(select_columns)?)
+}
+
+fn single_groupby(
+    tx: &Impute,
+    dataframe: Arc<DataFrame>,
+    value: ScalarValue,
+) -> Result<Arc<DataFrame>> {
+    // Save off names of columns in the original input DataFrame
+    let original_columns: Vec<_> = dataframe
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect();
+
+    // First step is to build up a new DataFrame that contains the all possible combinations
+    // of the `key` and `groupby` columns
+
+    // We're only supporting a single groupby column for now
+    let groupby = tx.groupby.get(0).unwrap().clone();
+
+    // Make separate dataframes containing all unique values of the `key` and `groupby` columns
+    let key_df = dataframe.aggregate(vec![col(&tx.key)], Vec::new())?;
+    let groupby_df = dataframe.aggregate(vec![col(&groupby)], Vec::new())?;
+
+    // DataFusion doesn't yet expose the cross join operation through the DataFrame
+    // API, so for now we implement the cross join by adding dummy constant values columns
+    // to each
+    let key_df = key_df.select(vec![Expr::Wildcard, lit(true).alias("__true_key")])?;
+    let groupby_df = groupby_df.select(vec![Expr::Wildcard, lit(true).alias("__true_groupby")])?;
+    let all_combos_df = key_df
+        .join(
+            groupby_df,
+            JoinType::Inner,
+            &["__true_key"],
+            &["__true_groupby"],
+            None,
+        )?
+        .select_columns(&[&tx.key, &groupby])?;
+
+    // Next we take the input DataFrame and
+    //  1) Rename the key and groupby columns to avoid collision on join
+    //  2) Add a __row_number column that we can sort by at the end to preserver the input
+    //     row order
+    let mut select_columns: Vec<_> = dataframe
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| {
+            if field.name() == &tx.key {
+                col(field.name()).alias("__key")
+            } else if field.name() == &groupby {
+                col(field.name()).alias("__groupby")
+            } else {
+                col(field.name())
+            }
+        })
+        .collect();
+
+    let row_number_expr = Expr::WindowFunction {
+        fun: WindowFunction::BuiltInWindowFunction(BuiltInWindowFunction::RowNumber),
+        args: Vec::new(),
+        partition_by: Vec::new(),
+        order_by: Vec::new(),
+        window_frame: None,
+    }
+    .alias("__row_number");
+
+    select_columns.push(row_number_expr);
+
+    let dataframe = dataframe.select(select_columns)?;
+
+    // Now join dataframe on key and groupby columns. Use a left outer join to introduce new
+    // rows for combinations of groupby and key that were not originally present.
+    // Also sort by __row_number to restore the original ordering of the input DataFrame with
+    // null values (which will be replaced below) are pushed to the end.
+    let joined = all_combos_df
+        .join(
+            dataframe,
+            JoinType::Left,
+            &[&tx.key, &groupby],
+            &["__key", "__groupby"],
+            None,
+        )?
+        .sort(vec![Expr::Sort {
+            expr: Box::new(col("__row_number")),
+            asc: true,
+            nulls_first: false,
+        }])?;
+
+    // Finally, select all of the original DataFrame columns, filling in missing values
+    // of the `field` columns
+    let mut select_columns: Vec<_> = original_columns
+        .iter()
+        .map(|col_name| {
+            if col_name == &tx.field {
+                when(col(&tx.field).is_not_null(), col(&tx.field))
+                    .otherwise(lit(value.clone()))
+                    .unwrap()
+                    .alias(&tx.field)
+            } else {
+                col(col_name)
+            }
+        })
+        .collect();
+
+    // Add undocumented "_impute" column that Vega adds
+    select_columns.push(
+        when(
+            col(&tx.field).is_not_null(),
+            Expr::Literal(ScalarValue::Boolean(None)),
+        )
+        .otherwise(lit(true))
+        .unwrap()
+        .alias("_impute"),
+    );
+
+    let dataframe = joined.select(select_columns)?;
+    Ok(dataframe)
+}

--- a/vegafusion-rt-datafusion/src/transform/mod.rs
+++ b/vegafusion-rt-datafusion/src/transform/mod.rs
@@ -12,6 +12,7 @@ pub mod collect;
 pub mod extent;
 pub mod filter;
 pub mod formula;
+pub mod impute;
 pub mod joinaggregate;
 pub mod pipeline;
 pub mod project;
@@ -54,6 +55,7 @@ pub fn to_transform_trait(tx: &TransformKind) -> &dyn TransformTrait {
         TransformKind::Window(tx) => tx,
         TransformKind::Project(tx) => tx,
         TransformKind::Stack(tx) => tx,
+        TransformKind::Impute(tx) => tx,
     }
 }
 

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/area_gradient.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/area_gradient.comm_plan.json
@@ -2,7 +2,7 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/area_overlay.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/area_overlay.comm_plan.json
@@ -2,11 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "data_1",
+      "name": "data_0",
       "scope": []
     }, {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/interactive_legend.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/interactive_legend.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_series",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/interactive_legend_dblclick.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/interactive_legend_dblclick.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_series",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/interactive_overview_detail.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/interactive_overview_detail.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "data_1",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_series",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_normalize.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_normalize.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_series",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_ordinal.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_ordinal.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_Cylinders",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_overlay.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_overlay.comm_plan.json
@@ -2,7 +2,15 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_gender",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_x_domain_age",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_stream.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_area_stream.comm_plan.json
@@ -2,7 +2,11 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    }, {
+      "namespace": "data",
+      "name": "source_0_color_domain_series",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/test_transform_impute.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_impute.rs
@@ -1,0 +1,93 @@
+#[macro_use]
+extern crate lazy_static;
+
+mod util;
+use util::check::check_transform_evaluation;
+
+#[cfg(test)]
+mod test_impute {
+    use crate::check_transform_evaluation;
+    use crate::util::equality::TablesEqualConfig;
+    use serde_json::json;
+    use vegafusion_core::data::table::VegaFusionTable;
+    use vegafusion_core::spec::transform::impute::{ImputeMethodSpec, ImputeTransformSpec};
+    use vegafusion_core::spec::transform::TransformSpec;
+    use vegafusion_core::spec::values::Field;
+
+    fn simple_dataset() -> VegaFusionTable {
+        VegaFusionTable::from_json(
+            &json!([
+                {"a": 0, "b": 28, "c": 0, "d": -1},
+                {"a": 0, "b": 91, "c": 1, "d": -2},
+                {"a": 1, "b": 43, "c": 0, "d": -3},
+                {"a": 1, "b": 55, "c": 1, "d": -4},
+                {"a": 3, "b": 19, "c": 0, "d": -7},
+                {"a": 2, "b": 81, "c": 0, "d": -5},
+                {"a": 2, "b": 53, "c": 1, "d": -6},
+
+            ]),
+            1024,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_one_groupby() {
+        let dataset = simple_dataset();
+
+        let impute_spec = ImputeTransformSpec {
+            field: Field::String("b".to_string()),
+            key: Field::String("a".to_string()),
+            keyvals: None,
+            method: Some(ImputeMethodSpec::Value),
+            groupby: Some(vec![Field::String("c".to_string())]),
+            value: Some(json!(0.0)),
+            extra: Default::default(),
+        };
+
+        let transform_specs = vec![TransformSpec::Impute(impute_spec)];
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+
+    #[test]
+    fn test_zero_groupby() {
+        let dataset = simple_dataset();
+
+        let impute_spec = ImputeTransformSpec {
+            field: Field::String("b".to_string()),
+            key: Field::String("a".to_string()),
+            keyvals: None,
+            method: Some(ImputeMethodSpec::Value),
+            groupby: None,
+            value: Some(json!(0.0)),
+            extra: Default::default(),
+        };
+
+        let transform_specs = vec![TransformSpec::Impute(impute_spec)];
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+}


### PR DESCRIPTION
## Overview
This PR adds support for evaluating certain configurations of the Vega [`impute`](https://vega.github.io/vega/docs/transforms/impute/) transform in the VegaFusion Runtime.  This initial implementation aims to support Vega-Lite's use of `impute` when generating stacked area charts.

## Limitations
This implementation only supports the following subset of the functionality of `impute`
 - `method` must be 'value'
 - `groupby` must be a list of zero or one field.

Other uses of impute are detected and the planner pushes them into the client specification