### PR TITLE
Add planner warning to pre_transform_spec when unsupported transforms are found

### DIFF
--- a/python/vegafusion/tests/test_pretransform.py
+++ b/python/vegafusion/tests/test_pretransform.py
@@ -74,6 +74,137 @@ def order_items_spec():
 """
 
 
+def movies_histogram_spec(agg = "count"):
+    return """
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 200,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {
+      "name": "source_0",
+      "url": "data/movies.json",
+      "format": {"type": "json"},
+      "transform": [
+        {
+          "type": "extent",
+          "field": "IMDB Rating",
+          "signal": "bin_maxbins_10_IMDB_Rating_extent"
+        },
+        {
+          "type": "bin",
+          "field": "IMDB Rating",
+          "as": [
+            "bin_maxbins_10_IMDB Rating",
+            "bin_maxbins_10_IMDB Rating_end"
+          ],
+          "signal": "bin_maxbins_10_IMDB_Rating_bins",
+          "extent": {"signal": "bin_maxbins_10_IMDB_Rating_extent"},
+          "maxbins": 10
+        },
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_maxbins_10_IMDB Rating",
+            "bin_maxbins_10_IMDB Rating_end"
+          ],
+          "ops": [""" + '"' + agg + '"' + r"""],
+          "fields": ["Worldwide Gross"],
+          "as": ["median_Worldwide Gross"]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"bin_maxbins_10_IMDB Rating\"]) && isFinite(+datum[\"bin_maxbins_10_IMDB Rating\"]) && isValid(datum[\"median_Worldwide Gross\"]) && isFinite(+datum[\"median_Worldwide Gross\"])"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "rect",
+      "style": ["bar"],
+      "from": {"data": "source_0"},
+      "encode": {
+        "update": {
+          "fill": {"value": "#4c78a8"},
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"IMDB Rating (binned): \" + (!isValid(datum[\"bin_maxbins_10_IMDB Rating\"]) || !isFinite(+datum[\"bin_maxbins_10_IMDB Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB Rating\"], \"\") + \" – \" + format(datum[\"bin_maxbins_10_IMDB Rating_end\"], \"\")) + \"; Median of Worldwide Gross: \" + (format(datum[\"median_Worldwide Gross\"], \"\"))"
+          },
+          "x2": {
+            "scale": "x",
+            "field": "bin_maxbins_10_IMDB Rating",
+            "offset": 1
+          },
+          "x": {"scale": "x", "field": "bin_maxbins_10_IMDB Rating_end"},
+          "y": {"scale": "y", "field": "median_Worldwide Gross"},
+          "y2": {"scale": "y", "value": 0}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": {
+        "signal": "[bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop]"
+      },
+      "range": [0, {"signal": "width"}],
+      "bins": {"signal": "bin_maxbins_10_IMDB_Rating_bins"},
+      "zero": false
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "source_0", "field": "median_Worldwide Gross"},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "y",
+      "orient": "left",
+      "gridScale": "x",
+      "grid": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "IMDB Rating (binned)",
+      "labelFlush": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(width/10)"},
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "Median of Worldwide Gross",
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ]
+}"""
+
+
 def test_pre_transform_multi_partition():
     n = 4050
     order_items = pd.DataFrame({
@@ -139,3 +270,18 @@ def test_pre_transform_datasets():
     expected = pd.DataFrame({"menu_item": [0, 1, 2], "__count": [n, 2 * n, 3 * n]})
     pd.testing.assert_frame_equal(datasets[0], expected)
 
+
+def test_pre_transform_planner_warning():
+    # Pre-transform with supported aggregate function should result in no warnings
+    vega_spec = movies_histogram_spec("mean")
+    datasets, warnings = vf.runtime.pre_transform_spec(vega_spec, "UTC")
+    assert len(warnings) == 0
+
+    # Pre-transform with unsupported aggregate function should result in one warning
+    vega_spec = movies_histogram_spec("ci0")
+    datasets, warnings = vf.runtime.pre_transform_spec(vega_spec, "UTC")
+    assert len(warnings) == 1
+
+    warning = warnings[0]
+    assert warning["type"] == "Planner"
+    assert "source_0" in warning["message"]

--- a/vegafusion-core/src/planning/extract.rs
+++ b/vegafusion-core/src/planning/extract.rs
@@ -8,7 +8,7 @@
  */
 use crate::error::Result;
 use crate::planning::dependency_graph::{get_supported_data_variables, scoped_var_for_input_var};
-use crate::proto::gen::tasks::Variable;
+use crate::proto::gen::tasks::{Variable, VariableNamespace};
 use crate::spec::chart::{ChartSpec, MutChartVisitor};
 use crate::spec::data::{DataSpec, DependencyNodeSupported};
 use crate::spec::mark::MarkSpec;
@@ -18,15 +18,28 @@ use crate::task_graph::scope::TaskScope;
 
 use crate::task_graph::graph::ScopedVariable;
 
-use crate::planning::plan::PlannerConfig;
+use crate::planning::plan::{PlannerConfig, PlannerWarnings};
 use std::collections::{HashMap, HashSet};
 
 pub fn extract_server_data(
     client_spec: &mut ChartSpec,
     task_scope: &mut TaskScope,
+    warnings: &mut Vec<PlannerWarnings>,
     config: &PlannerConfig,
 ) -> Result<ChartSpec> {
     let supported_vars = get_supported_data_variables(client_spec, config)?;
+
+    // Check for partially or unsupported data variables
+    for (var, dep) in supported_vars.iter() {
+        if matches!(var.0.ns(), VariableNamespace::Data) && !matches!(dep, DependencyNodeSupported::Supported) {
+            let message = if var.1.is_empty() {
+                format!("Some transforms applied to the '{}' dataset are not yet supported", var.0.name)
+            } else {
+                format!("Some transforms applied to the '{}' dataset with scope {:?} are not yet supported", var.0.name, var.1.as_slice())
+            };
+            warnings.push(PlannerWarnings::UnsupportedTransforms(message));
+        }
+    }
 
     let mut extract_server_visitor =
         ExtractServerDependenciesVisitor::new(supported_vars, task_scope);

--- a/vegafusion-core/src/planning/extract.rs
+++ b/vegafusion-core/src/planning/extract.rs
@@ -31,9 +31,14 @@ pub fn extract_server_data(
 
     // Check for partially or unsupported data variables
     for (var, dep) in supported_vars.iter() {
-        if matches!(var.0.ns(), VariableNamespace::Data) && !matches!(dep, DependencyNodeSupported::Supported) {
+        if matches!(var.0.ns(), VariableNamespace::Data)
+            && !matches!(dep, DependencyNodeSupported::Supported)
+        {
             let message = if var.1.is_empty() {
-                format!("Some transforms applied to the '{}' dataset are not yet supported", var.0.name)
+                format!(
+                    "Some transforms applied to the '{}' dataset are not yet supported",
+                    var.0.name
+                )
             } else {
                 format!("Some transforms applied to the '{}' dataset with scope {:?} are not yet supported", var.0.name, var.1.as_slice())
             };

--- a/vegafusion-core/src/planning/plan.rs
+++ b/vegafusion-core/src/planning/plan.rs
@@ -18,12 +18,14 @@ use crate::spec::chart::ChartSpec;
 #[derive(Clone, Debug)]
 pub enum PlannerWarnings {
     StringifyDatetimeMixedUsage(String),
+    UnsupportedTransforms(String),
 }
 
 impl PlannerWarnings {
     pub fn message(&self) -> String {
         match &self {
             PlannerWarnings::StringifyDatetimeMixedUsage(message) => message.clone(),
+            PlannerWarnings::UnsupportedTransforms(message) => message.clone(),
         }
     }
 }
@@ -58,7 +60,7 @@ pub struct SpecPlan {
 
 impl SpecPlan {
     pub fn try_new(full_spec: &ChartSpec, config: &PlannerConfig) -> Result<Self> {
-        let warnings: Vec<PlannerWarnings> = Vec::new();
+        let mut warnings: Vec<PlannerWarnings> = Vec::new();
 
         let mut client_spec = full_spec.clone();
 
@@ -76,7 +78,7 @@ impl SpecPlan {
 
         let mut task_scope = client_spec.to_task_scope()?;
 
-        let mut server_spec = extract_server_data(&mut client_spec, &mut task_scope, config)?;
+        let mut server_spec = extract_server_data(&mut client_spec, &mut task_scope, &mut warnings, config)?;
         let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut client_spec)?;
 
         if config.split_url_data_nodes {

--- a/vegafusion-core/src/planning/plan.rs
+++ b/vegafusion-core/src/planning/plan.rs
@@ -78,7 +78,8 @@ impl SpecPlan {
 
         let mut task_scope = client_spec.to_task_scope()?;
 
-        let mut server_spec = extract_server_data(&mut client_spec, &mut task_scope, &mut warnings, config)?;
+        let mut server_spec =
+            extract_server_data(&mut client_spec, &mut task_scope, &mut warnings, config)?;
         let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut client_spec)?;
 
         if config.split_url_data_nodes {

--- a/vegafusion-rt-datafusion/tests/test_planning.rs
+++ b/vegafusion-rt-datafusion/tests/test_planning.rs
@@ -31,7 +31,13 @@ async fn test_extract_server_data() {
     // println!("{:#?}", task_scope);
 
     let mut warnings: Vec<PlannerWarnings> = Vec::new();
-    let server_spec = extract_server_data(&mut spec, &mut task_scope, &mut warnings, &Default::default()).unwrap();
+    let server_spec = extract_server_data(
+        &mut spec,
+        &mut task_scope,
+        &mut warnings,
+        &Default::default(),
+    )
+    .unwrap();
     // println!("{}", serde_json::to_string_pretty(&server_spec).unwrap());
 
     let client_defs: HashSet<_> = spec.definition_vars().unwrap().into_iter().collect();
@@ -108,8 +114,13 @@ async fn test_extract_stitch_data() {
     let mut task_scope = spec.to_task_scope().unwrap();
 
     let mut warnings: Vec<PlannerWarnings> = Vec::new();
-    let mut server_spec =
-        extract_server_data(&mut spec, &mut task_scope, &mut warnings, &Default::default()).unwrap();
+    let mut server_spec = extract_server_data(
+        &mut spec,
+        &mut task_scope,
+        &mut warnings,
+        &Default::default(),
+    )
+    .unwrap();
     let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec).unwrap();
 
     println!("{:#?}", comm_plan);
@@ -128,8 +139,13 @@ async fn try_extract_split_server_data() {
     let mut task_scope = spec.to_task_scope().unwrap();
 
     let mut warnings: Vec<PlannerWarnings> = Vec::new();
-    let mut server_spec =
-        extract_server_data(&mut spec, &mut task_scope, &mut warnings, &Default::default()).unwrap();
+    let mut server_spec = extract_server_data(
+        &mut spec,
+        &mut task_scope,
+        &mut warnings,
+        &Default::default(),
+    )
+    .unwrap();
     let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec).unwrap();
 
     println!("{:#?}", comm_plan);

--- a/vegafusion-rt-datafusion/tests/test_planning.rs
+++ b/vegafusion-rt-datafusion/tests/test_planning.rs
@@ -13,6 +13,7 @@ use vegafusion_rt_datafusion::task_graph::runtime::TaskGraphRuntime;
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use vegafusion_core::planning::plan::PlannerWarnings;
 use vegafusion_core::planning::split_domain_data::split_domain_data;
 
 use vegafusion_core::planning::stitch::stitch_specs;
@@ -29,7 +30,8 @@ async fn test_extract_server_data() {
     let mut task_scope = spec.to_task_scope().unwrap();
     // println!("{:#?}", task_scope);
 
-    let server_spec = extract_server_data(&mut spec, &mut task_scope, &Default::default()).unwrap();
+    let mut warnings: Vec<PlannerWarnings> = Vec::new();
+    let server_spec = extract_server_data(&mut spec, &mut task_scope, &mut warnings, &Default::default()).unwrap();
     // println!("{}", serde_json::to_string_pretty(&server_spec).unwrap());
 
     let client_defs: HashSet<_> = spec.definition_vars().unwrap().into_iter().collect();
@@ -105,8 +107,9 @@ async fn test_extract_stitch_data() {
     // Get full spec's scope
     let mut task_scope = spec.to_task_scope().unwrap();
 
+    let mut warnings: Vec<PlannerWarnings> = Vec::new();
     let mut server_spec =
-        extract_server_data(&mut spec, &mut task_scope, &Default::default()).unwrap();
+        extract_server_data(&mut spec, &mut task_scope, &mut warnings, &Default::default()).unwrap();
     let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec).unwrap();
 
     println!("{:#?}", comm_plan);
@@ -124,8 +127,9 @@ async fn try_extract_split_server_data() {
     // Get full spec's scope
     let mut task_scope = spec.to_task_scope().unwrap();
 
+    let mut warnings: Vec<PlannerWarnings> = Vec::new();
     let mut server_spec =
-        extract_server_data(&mut spec, &mut task_scope, &Default::default()).unwrap();
+        extract_server_data(&mut spec, &mut task_scope, &mut warnings, &Default::default()).unwrap();
     let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec).unwrap();
 
     println!("{:#?}", comm_plan);


### PR DESCRIPTION
Adds a new warning that gets returned by `pre_transform_spec` when not all transforms for a dataset can be pre-evaluated.

