### PR TITLE
Restore support for Week and DayOfYear TimeUnits

### DIFF
--- a/vegafusion-core/src/spec/transform/timeunit.rs
+++ b/vegafusion-core/src/spec/transform/timeunit.rs
@@ -71,24 +71,12 @@ pub enum TimeUnitUnitSpec {
 
 impl TransformSpecTrait for TimeUnitTransformSpec {
     fn supported(&self) -> bool {
-        if self.units.is_none()
+        let unsupported = self.units.is_none()
             || self.step.is_some()
             || self.extent.is_some()
             || self.maxbins.is_some()
-            || self.signal.is_some()
-        {
-            false
-        } else {
-            if let Some(units) = &self.units {
-                for unit in units {
-                    if matches!(unit, TimeUnitUnitSpec::Week | TimeUnitUnitSpec::DayOfYear) {
-                        // week and dayofyear units are not yet supported
-                        return false;
-                    }
-                }
-            }
-            true
-        }
+            || self.signal.is_some();
+        !unsupported
     }
 
     fn output_signals(&self) -> Vec<String> {

--- a/vegafusion-rt-datafusion/src/expression/compiler/call.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/call.rs
@@ -63,6 +63,7 @@ use crate::expression::compiler::builtin_functions::type_coercion::to_boolean::t
 use crate::expression::compiler::builtin_functions::type_coercion::to_number::to_number_transform;
 use crate::expression::compiler::builtin_functions::type_coercion::to_string::to_string_transform;
 use crate::task_graph::timezone::RuntimeTzConfig;
+use crate::transform::timeunit::TIMEUNIT_START_UDF;
 
 pub type MacroFn = Arc<dyn Fn(&[Expression]) -> Result<Expression> + Send + Sync>;
 pub type TransformFn = Arc<dyn Fn(&[Expr], &DFSchema) -> Result<Expr> + Send + Sync>;
@@ -453,6 +454,9 @@ pub fn make_session_context() -> SessionContext {
     ctx.register_udf((*STR_TO_TIMESTAMPTZ_UDF).clone());
     ctx.register_udf((*MAKE_TIMESTAMPTZ).clone());
     ctx.register_udf((*TIMESTAMPTZ_TO_EPOCH_MS).clone());
+
+    // timeunit
+    ctx.register_udf((*TIMEUNIT_START_UDF).clone());
 
     // timeformat
     ctx.register_udf((*FORMAT_TIMESTAMP_UDF).clone());

--- a/vegafusion-rt-datafusion/src/sql/connection/datafusion_conn.rs
+++ b/vegafusion-rt-datafusion/src/sql/connection/datafusion_conn.rs
@@ -40,6 +40,9 @@ pub fn make_datafusion_dialect() -> Dialect {
     functions.insert("make_timestamptz".to_string());
     functions.insert("timestamptz_to_epoch_ms".to_string());
 
+    // timeunit
+    functions.insert("vega_timeunit".to_string());
+
     // timeformat
     functions.insert("format_timestamp".to_string());
 

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -910,12 +910,12 @@ mod test_image_comparison_timeunit {
             vec![TimeUnitUnitSpec::Year],
             vec![TimeUnitUnitSpec::Quarter],
             vec![TimeUnitUnitSpec::Month],
-            // vec![TimeUnitUnitSpec::Week],
+            vec![TimeUnitUnitSpec::Week],
             vec![TimeUnitUnitSpec::Date],
             vec![TimeUnitUnitSpec::Day],
             vec![TimeUnitUnitSpec::Year, TimeUnitUnitSpec::Quarter],
             vec![TimeUnitUnitSpec::Year, TimeUnitUnitSpec::Month],
-            // vec![TimeUnitUnitSpec::Year, TimeUnitUnitSpec::Week],
+            vec![TimeUnitUnitSpec::Year, TimeUnitUnitSpec::Week],
         )]
         units: Vec<TimeUnitUnitSpec>,
 


### PR DESCRIPTION
This PR restores support for `week` and `dayofyear` time units.  This was unintentionally dropped during the great SQL refactor.

This is done by reintroducing the legacy timeunit logic as a fallback DataFusion UDF.
