### PR TITLE
Fix crash in pivot transform for column with spaces

### DIFF
--- a/vegafusion-rt-datafusion/src/transform/pivot.rs
+++ b/vegafusion-rt-datafusion/src/transform/pivot.rs
@@ -8,10 +8,10 @@ use crate::transform::aggregate::make_aggr_expr;
 use crate::transform::utils::RecordBatchUtils;
 use crate::transform::TransformTrait;
 use async_trait::async_trait;
-use datafusion_expr::{coalesce, col, lit, min, BuiltInWindowFunction, Expr, WindowFunction};
+use datafusion::prelude::Column;
+use datafusion_expr::{coalesce, lit, min, BuiltInWindowFunction, Expr, WindowFunction};
 use sqlgen::dialect::DialectDisplay;
 use std::sync::Arc;
-use datafusion::prelude::Column;
 use vegafusion_core::arrow::array::StringArray;
 use vegafusion_core::arrow::datatypes::DataType;
 use vegafusion_core::error::{Result, ResultWithContext, VegaFusionError};
@@ -71,9 +71,10 @@ async fn extract_sorted_pivot_values(
 
     let sorted_query = agg_query.sort(
         vec![Expr::Sort {
-            expr: Box::new(
-                Expr::Column(Column{ relation: Some(agg_query.parent_name()), name: tx.field.clone() })
-            ),
+            expr: Box::new(Expr::Column(Column {
+                relation: Some(agg_query.parent_name()),
+                name: tx.field.clone(),
+            })),
             asc: true,
             nulls_first: false,
         }],

--- a/vegafusion-rt-datafusion/src/transform/pivot.rs
+++ b/vegafusion-rt-datafusion/src/transform/pivot.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use datafusion_expr::{coalesce, col, lit, min, BuiltInWindowFunction, Expr, WindowFunction};
 use sqlgen::dialect::DialectDisplay;
 use std::sync::Arc;
+use datafusion::prelude::Column;
 use vegafusion_core::arrow::array::StringArray;
 use vegafusion_core::arrow::datatypes::DataType;
 use vegafusion_core::error::{Result, ResultWithContext, VegaFusionError};
@@ -70,7 +71,9 @@ async fn extract_sorted_pivot_values(
 
     let sorted_query = agg_query.sort(
         vec![Expr::Sort {
-            expr: Box::new(col(&format!("{}.{}", agg_query.parent_name(), tx.field))),
+            expr: Box::new(
+                Expr::Column(Column{ relation: Some(agg_query.parent_name()), name: tx.field.clone() })
+            ),
             asc: true,
             nulls_first: false,
         }],

--- a/vegafusion-rt-datafusion/tests/specs/custom/sorted_pivot_lines.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/sorted_pivot_lines.comm_plan.json
@@ -1,0 +1,35 @@
+{
+  "server_to_client": [
+    {
+      "namespace": "data",
+      "name": "data_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_0_layer_0_layer_0_color_domain_MPAA Rating_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_layer_0_layer_0_color_domain_MPAA Rating_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/sorted_pivot_lines.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/sorted_pivot_lines.vg.json
@@ -1,0 +1,412 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 200,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {"name": "pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_store"},
+    {
+      "name": "df",
+      "url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/movies.json",
+      "format": {"type": "json", "parse": {"Release Date": "date"}}
+    },
+    {
+      "name": "data_0",
+      "source": "df",
+      "transform": [
+        {
+          "field": "Release Date",
+          "type": "timeunit",
+          "units": ["year"],
+          "as": ["year_Release Date", "year_Release Date_end"]
+        }
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "(isDate(datum[\"year_Release Date\"]) || (isValid(datum[\"year_Release Date\"]) && isFinite(+datum[\"year_Release Date\"]))) && isValid(datum[\"US Gross\"]) && isFinite(+datum[\"US Gross\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "df",
+      "transform": [
+        {
+          "type": "pivot",
+          "field": "MPAA Rating",
+          "value": "US Gross",
+          "groupby": ["Release Date"]
+        },
+        {
+          "type": "formula",
+          "expr": "toDate(datum[\"Release Date\"])",
+          "as": "Release Date"
+        },
+        {
+          "field": "Release Date",
+          "type": "timeunit",
+          "units": ["year"],
+          "as": ["year_Release Date", "year_Release Date_end"]
+        },
+        {
+          "type": "filter",
+          "expr": "(isDate(datum[\"year_Release Date\"]) || (isValid(datum[\"year_Release Date\"]) && isFinite(+datum[\"year_Release Date\"])))"
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "df",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["MPAA Rating"],
+          "ops": [],
+          "fields": [],
+          "as": []
+        },
+        {
+          "type": "window",
+          "params": [null],
+          "as": ["rank"],
+          "ops": ["rank"],
+          "fields": [null],
+          "sort": {"field": [], "order": []}
+        },
+        {"type": "filter", "expr": "datum.rank <= 21"}
+      ]
+    }
+  ],
+  "signals": [
+    {
+      "name": "unit",
+      "value": {},
+      "on": [
+        {"events": "mousemove", "update": "isTuple(group()) ? group() : unit"}
+      ]
+    },
+    {
+      "name": "pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24",
+      "update": "vlSelectionResolve(\"pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_store\", \"union\", true, true)"
+    },
+    {
+      "name": "pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_tuple",
+      "on": [
+        {
+          "events": [
+            {
+              "source": "scope",
+              "type": "mouseover",
+              "markname": "layer_0_layer_1_layer_0_voronoi"
+            }
+          ],
+          "update": "datum && item().mark.marktype !== 'group' && indexof(item().mark.role, 'legend') < 0 ? {unit: \"layer_0_layer_1_layer_0\", fields: pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"year_Release Date\"]]} : null",
+          "force": true
+        },
+        {"events": [{"source": "view", "type": "mouseout"}], "update": "null"}
+      ]
+    },
+    {
+      "name": "pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_tuple_fields",
+      "value": [{"type": "E", "field": "year_Release Date"}]
+    },
+    {
+      "name": "pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_toggle",
+      "value": false,
+      "on": [
+        {
+          "events": [
+            {
+              "source": "scope",
+              "type": "mouseover",
+              "markname": "layer_0_layer_1_layer_0_voronoi"
+            }
+          ],
+          "update": "event.shiftKey"
+        },
+        {"events": [{"source": "view", "type": "mouseout"}], "update": "false"}
+      ]
+    },
+    {
+      "name": "pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_modify",
+      "on": [
+        {
+          "events": {
+            "signal": "pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_tuple"
+          },
+          "update": "modify(\"pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_store\", pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_toggle ? null : pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_tuple, pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_toggle ? null : true, pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_toggle ? pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_tuple : null)"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "layer_0_layer_0_layer_0_pathgroup",
+      "type": "group",
+      "from": {
+        "facet": {
+          "name": "faceted_path_layer_0_layer_0_layer_0_main",
+          "data": "data_0",
+          "groupby": ["MPAA Rating"]
+        }
+      },
+      "encode": {
+        "update": {
+          "width": {"field": {"group": "width"}},
+          "height": {"field": {"group": "height"}}
+        }
+      },
+      "marks": [
+        {
+          "name": "layer_0_layer_0_layer_0_marks",
+          "type": "line",
+          "clip": true,
+          "style": ["line"],
+          "sort": {"field": "datum[\"year_Release Date\"]"},
+          "interactive": false,
+          "from": {"data": "faceted_path_layer_0_layer_0_layer_0_main"},
+          "encode": {
+            "update": {
+              "stroke": {
+                "scale": "layer_0_layer_0_color",
+                "field": "MPAA Rating"
+              },
+              "opacity": {"value": 1},
+              "description": {
+                "signal": "\"Release Date (year): \" + (timeFormat(datum[\"year_Release Date\"], timeUnitSpecifier([\"year\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; US Gross: \" + (format(datum[\"US Gross\"], \"\")) + \"; MPAA Rating: \" + (isValid(datum[\"MPAA Rating\"]) ? datum[\"MPAA Rating\"] : \"\"+datum[\"MPAA Rating\"])"
+              },
+              "x": {"scale": "x", "field": "year_Release Date"},
+              "y": {"scale": "y", "field": "US Gross"},
+              "defined": {
+                "signal": "isValid(datum[\"year_Release Date\"]) && isFinite(+datum[\"year_Release Date\"]) && isValid(datum[\"US Gross\"]) && isFinite(+datum[\"US Gross\"])"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "__drilldown_brush_marks",
+      "type": "symbol",
+      "style": ["point"],
+      "interactive": false,
+      "from": {"data": "data_1"},
+      "encode": {
+        "update": {
+          "opacity": {"value": 0},
+          "fill": {"value": "transparent"},
+          "stroke": {"scale": "layer_0_layer_0_color", "field": "MPAA Rating"},
+          "ariaRoleDescription": {"value": "point"},
+          "description": {
+            "signal": "\"Release Date (year): \" + (timeFormat(datum[\"year_Release Date\"], timeUnitSpecifier([\"year\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; US Gross: \" + (format(datum[\"US Gross\"], \"\")) + \"; MPAA Rating: \" + (isValid(datum[\"MPAA Rating\"]) ? datum[\"MPAA Rating\"] : \"\"+datum[\"MPAA Rating\"])"
+          },
+          "x": {"scale": "x", "field": "year_Release Date"},
+          "y": {"scale": "y", "field": "US Gross"}
+        }
+      }
+    },
+    {
+      "name": "layer_0_layer_0_layer_2_marks",
+      "type": "symbol",
+      "style": ["point"],
+      "interactive": false,
+      "from": {"data": "data_1"},
+      "encode": {
+        "update": {
+          "opacity": [
+            {
+              "test": "length(data(\"pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_store\")) && vlSelectionTest(\"pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_store\", datum)",
+              "value": 1
+            },
+            {"value": 0}
+          ],
+          "fill": {"value": "transparent"},
+          "stroke": {"scale": "layer_0_layer_0_color", "field": "MPAA Rating"},
+          "ariaRoleDescription": {"value": "point"},
+          "description": {
+            "signal": "\"Release Date (year): \" + (timeFormat(datum[\"year_Release Date\"], timeUnitSpecifier([\"year\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; US Gross: \" + (format(datum[\"US Gross\"], \"\")) + \"; MPAA Rating: \" + (isValid(datum[\"MPAA Rating\"]) ? datum[\"MPAA Rating\"] : \"\"+datum[\"MPAA Rating\"])"
+          },
+          "x": {"scale": "x", "field": "year_Release Date"},
+          "y": {"scale": "y", "field": "US Gross"},
+          "size": {"value": 80}
+        }
+      }
+    },
+    {
+      "name": "layer_0_layer_1_layer_0_marks",
+      "type": "rule",
+      "style": ["rule"],
+      "interactive": true,
+      "from": {"data": "data_2"},
+      "encode": {
+        "update": {
+          "stroke": {"value": "CHART_DEFAULT_RULE_COLOR_MARKER"},
+          "opacity": [
+            {
+              "test": "length(data(\"pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_store\")) && vlSelectionTest(\"pivot_hover_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_store\", datum)",
+              "value": 0.3
+            },
+            {"value": 0}
+          ],
+          "tooltip": {
+            "signal": "{\"Release Date (year)\": timeFormat(datum[\"year_Release Date\"], timeUnitSpecifier([\"year\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))}"
+          },
+          "description": {
+            "signal": "\"Release Date (year): \" + (timeFormat(datum[\"year_Release Date\"], timeUnitSpecifier([\"year\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"})))"
+          },
+          "x": {"scale": "x", "field": "year_Release Date"},
+          "y": {"value": 0},
+          "y2": {"field": {"group": "height"}}
+        }
+      }
+    },
+    {
+      "name": "layer_0_layer_1_layer_0_voronoi",
+      "type": "path",
+      "interactive": true,
+      "from": {"data": "layer_0_layer_1_layer_0_marks"},
+      "encode": {
+        "update": {
+          "fill": {"value": "transparent"},
+          "strokeWidth": {"value": 0.35},
+          "stroke": {"value": "transparent"},
+          "isVoronoi": {"value": true},
+          "tooltip": {
+            "signal": "{\"Release Date (year)\": timeFormat(datum.datum[\"year_Release Date\"], timeUnitSpecifier([\"year\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))}"
+          }
+        }
+      },
+      "transform": [
+        {
+          "type": "voronoi",
+          "x": {"expr": "datum.datum.x || 0"},
+          "y": {"expr": "datum.datum.y || 0"},
+          "size": [{"signal": "width"}, {"signal": "height"}]
+        }
+      ]
+    },
+    {
+      "name": "aggregate_color_spec_878b1bec_a2a8_42c5_b9ab_bfcf98f79b24_marks",
+      "type": "rule",
+      "style": ["rule"],
+      "interactive": false,
+      "from": {"data": "data_3"},
+      "encode": {"update": {}}
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "time",
+      "domain": {
+        "fields": [
+          {"data": "data_0", "field": "year_Release Date"},
+          {"data": "data_1", "field": "year_Release Date"},
+          {"data": "data_2", "field": "year_Release Date"}
+        ]
+      },
+      "range": [0, {"signal": "width"}]
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "fields": [
+          {"data": "data_0", "field": "US Gross"},
+          {"data": "data_1", "field": "US Gross"}
+        ]
+      },
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "layer_0_layer_0_color",
+      "type": "ordinal",
+      "domain": {
+        "fields": [
+          {"data": "data_0", "field": "MPAA Rating"},
+          {"data": "data_1", "field": "MPAA Rating"}
+        ],
+        "sort": true
+      },
+      "range": "category"
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": true,
+      "gridScale": "y",
+      "tickCount": {"signal": "ceil(width/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": true,
+      "gridScale": "x",
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "Release Date (year)",
+      "labels": true,
+      "ticks": true,
+      "format": {
+        "signal": "timeUnitSpecifier([\"year\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"})"
+      },
+      "labelFlush": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(width/40)"},
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "US Gross",
+      "labels": true,
+      "ticks": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ],
+  "legends": [
+    {
+      "symbolType": "stroke",
+      "stroke": "layer_0_layer_0_color",
+      "title": "MPAA Rating",
+      "encode": {"symbols": {"update": {"opacity": {"value": 1}}}}
+    }
+  ],
+  "config": {
+    "range": {"ramp": {"scheme": "yellowgreenblue"}},
+    "axis": {"domain": false},
+    "legend": {"orient": "right"}
+  }
+}

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -127,7 +127,8 @@ mod test_custom_specs {
         case("custom/period_in_field_name", 0.001, false),
         case("custom/period_space_in_field_name", 0.001, false),
         case("custom/pivot_tooltip1", 0.001, true),
-        case("custom/pivot_crash", 0.001, false)
+        case("custom/pivot_crash", 0.001, false),
+        case("custom/sorted_pivot_lines", 0.001, false)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {}", spec_name);


### PR DESCRIPTION
This PR fixes a crash for a pivot transform of the form:

```json
        {
          "type": "pivot",
          "field": "MPAA Rating",
          "value": "US Gross",
          "groupby": ["Release Date"]
        }
```

Where the pivot field has a space in the name