### PR TITLE
Copy inline JSON datasets directly to pre-transform output specs

### DIFF
--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/vl_selection_test.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/vl_selection_test.rs
@@ -140,12 +140,16 @@ impl FieldSpec {
 
         let expr = match self.typ {
             SelectionType::Enum => {
+                let field_type = field_col.get_type(schema)?;
                 let list_values: Vec<_> = if let ScalarValue::List(Some(elements), _) = &values {
                     // values already a list
-                    elements.iter().map(|el| lit(el.clone())).collect()
+                    elements
+                        .iter()
+                        .map(|el| cast_to(lit(el.clone()), &field_type, schema))
+                        .collect::<Result<Vec<_>>>()?
                 } else {
                     // convert values to single element list
-                    vec![lit(values.clone())]
+                    vec![cast_to(lit(values.clone()), &field_type, schema)?]
                 };
 
                 Expr::InList {

--- a/vegafusion-rt-datafusion/src/task_graph/runtime.rs
+++ b/vegafusion-rt-datafusion/src/task_graph/runtime.rs
@@ -309,24 +309,22 @@ impl TaskGraphRuntime {
                             });
                     let value = if let Some(input_values) = input_values {
                         input_values
-                    } else {
-                        if let Value::Array(values) = &export_update.value {
-                            if let Some(row_limit) = row_limit {
-                                let row_limit = row_limit as usize;
-                                if values.len() > row_limit {
-                                    limited_datasets.push(export_update.to_scoped_var().0);
-                                    Value::Array(Vec::from(&values[..row_limit]))
-                                } else {
-                                    Value::Array(values.clone())
-                                }
+                    } else if let Value::Array(values) = &export_update.value {
+                        if let Some(row_limit) = row_limit {
+                            let row_limit = row_limit as usize;
+                            if values.len() > row_limit {
+                                limited_datasets.push(export_update.to_scoped_var().0);
+                                Value::Array(Vec::from(&values[..row_limit]))
                             } else {
                                 Value::Array(values.clone())
                             }
                         } else {
-                            return Err(VegaFusionError::internal(
-                                "Expected Data value to be an Array",
-                            ));
+                            Value::Array(values.clone())
                         }
+                    } else {
+                        return Err(VegaFusionError::internal(
+                            "Expected Data value to be an Array",
+                        ));
                     };
 
                     // Set inline value

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_initial_selection.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_initial_selection.comm_plan.json
@@ -1,0 +1,4 @@
+{
+  "server_to_client": [],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_initial_selection.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/stacked_bar_initial_selection.vg.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {
+      "name": "click_store",
+      "values": [
+        {
+          "unit": "",
+          "fields": [
+            {"field": "number", "channel": "x", "type": "E"},
+            {"field": "group", "channel": "color", "type": "E"}
+          ],
+          "values": [2, "x"]
+        },
+        {
+          "unit": "",
+          "fields": [
+            {"field": "number", "channel": "x", "type": "E"},
+            {"field": "group", "channel": "color", "type": "E"}
+          ],
+          "values": [3, "z"]
+        }
+      ]
+    },
+    {
+      "name": "source_0",
+      "values": [
+        {"number": 1, "group": "x", "value": 0.1},
+        {"number": 1, "group": "y", "value": 0.6},
+        {"number": 1, "group": "z", "value": 0.9},
+        {"number": 2, "group": "x", "value": 0.7},
+        {"number": 2, "group": "y", "value": 0.2},
+        {"number": 2, "group": "z", "value": 1.1},
+        {"number": 3, "group": "x", "value": 0.6},
+        {"number": 3, "group": "y", "value": 0.1},
+        {"number": 3, "group": "z", "value": 0.2}
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "stack",
+          "groupby": ["number"],
+          "field": "value",
+          "sort": {"field": ["group"], "order": ["descending"]},
+          "as": ["value_start", "value_end"],
+          "offset": "zero"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"value\"]) && isFinite(+datum[\"value\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 20},
+    {
+      "name": "width",
+      "update": "bandspace(domain('x').length, 0.1, 0.05) * x_step"
+    },
+    {
+      "name": "unit",
+      "value": {},
+      "on": [
+        {"events": "mousemove", "update": "isTuple(group()) ? group() : unit"}
+      ]
+    },
+    {
+      "name": "click",
+      "update": "vlSelectionResolve(\"click_store\", \"union\", true, true)"
+    },
+    {
+      "name": "click_tuple",
+      "on": [
+        {
+          "events": [{"source": "scope", "type": "click"}],
+          "update": "datum && item().mark.marktype !== 'group' && indexof(item().mark.role, 'legend') < 0 ? {unit: \"\", fields: click_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"number\"], (item().isVoronoi ? datum.datum : datum)[\"group\"]]} : null",
+          "force": true
+        },
+        {"events": [{"source": "view", "type": "dblclick"}], "update": "null"}
+      ]
+    },
+    {
+      "name": "click_tuple_fields",
+      "value": [
+        {"field": "number", "channel": "x", "type": "E"},
+        {"field": "group", "channel": "color", "type": "E"}
+      ]
+    },
+    {
+      "name": "click_toggle",
+      "value": false,
+      "on": [
+        {
+          "events": [{"source": "scope", "type": "click"}],
+          "update": "event.shiftKey"
+        },
+        {"events": [{"source": "view", "type": "dblclick"}], "update": "false"}
+      ]
+    },
+    {
+      "name": "click_modify",
+      "on": [
+        {
+          "events": {"signal": "click_tuple"},
+          "update": "modify(\"click_store\", click_toggle ? null : click_tuple, click_toggle ? null : true, click_toggle ? click_tuple : null)"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "rect",
+      "style": ["bar"],
+      "interactive": true,
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "fill": {"scale": "color", "field": "group"},
+          "opacity": [
+            {
+              "test": "!length(data(\"click_store\")) || vlSelectionTest(\"click_store\", datum)",
+              "value": 1
+            },
+            {"value": 0.2}
+          ],
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"number: \" + (isValid(datum[\"number\"]) ? datum[\"number\"] : \"\"+datum[\"number\"]) + \"; value: \" + (format(datum[\"value\"], \"\")) + \"; group: \" + (isValid(datum[\"group\"]) ? datum[\"group\"] : \"\"+datum[\"group\"])"
+          },
+          "x": {"scale": "x", "field": "number"},
+          "width": {"signal": "max(0.25, bandwidth('x'))"},
+          "y": {"scale": "y", "field": "value_end"},
+          "y2": {"scale": "y", "field": "value_start"}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {"data": "data_0", "field": "number", "sort": true},
+      "range": {"step": {"signal": "x_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "data_0", "fields": ["value_start", "value_end"]},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "data_0", "field": "group", "sort": true},
+      "range": "category"
+    }
+  ],
+  "axes": [
+    {
+      "scale": "y",
+      "orient": "left",
+      "gridScale": "x",
+      "grid": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "number",
+      "labelAlign": "right",
+      "labelAngle": 270,
+      "labelBaseline": "middle",
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "value",
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ],
+  "legends": [
+    {
+      "fill": "color",
+      "symbolType": "square",
+      "title": "group",
+      "encode": {"symbols": {"update": {"opacity": {"value": 1}}}}
+    }
+  ],
+  "config": {
+    "range": {"ramp": {"scheme": "yellowgreenblue"}},
+    "axis": {"domain": false}
+  }
+}

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -129,7 +129,7 @@ mod test_custom_specs {
         case("custom/pivot_tooltip1", 0.001, true),
         case("custom/pivot_crash", 0.001, false),
         case("custom/sorted_pivot_lines", 0.001, false),
-        case("custom/stacked_bar_initial_selection", 0.001, false),
+        case("custom/stacked_bar_initial_selection", 0.001, false)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {}", spec_name);

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -128,7 +128,8 @@ mod test_custom_specs {
         case("custom/period_space_in_field_name", 0.001, false),
         case("custom/pivot_tooltip1", 0.001, true),
         case("custom/pivot_crash", 0.001, false),
-        case("custom/sorted_pivot_lines", 0.001, false)
+        case("custom/sorted_pivot_lines", 0.001, false),
+        case("custom/stacked_bar_initial_selection", 0.001, false),
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {}", spec_name);


### PR DESCRIPTION
Copy inline JSON datasets directly to pre-transform output specs, instead of round-tripping through Arrow.

## Background
Consider a stacked bar chart in Vega-Lite with a point selection to control the bar opacity:

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "data": {
    "values": [
      {"number": 1, "group": "x", "value":0.1},
      {"number": 1, "group": "y", "value":0.6},
      {"number": 1, "group": "z", "value":0.9},
      {"number": 2, "group": "x", "value":0.7},
      {"number": 2, "group": "y", "value":0.2},
      {"number": 2, "group": "z", "value":1.1},
      {"number": 3, "group": "x", "value":0.6},
      {"number": 3, "group": "y", "value":0.1},
      {"number": 3, "group": "z", "value":0.2}
    ]
  },
  "params": [
    {
        "name": "click",
        "value": [
            {"number": 2, "group": "x"},
            {"number": 3, "group": "z"},
        ],
        "select": {
            "type": "point",
            "encodings": ["x", "color"]
        }
    }
  ],
  "mark": "bar",
  "encoding": {
    "x": {"field": "number"},
    "y": {"field": "value", "type": "quantitative"},
    "color": {"field": "group"},
    "opacity": {"condition": {"param": "click", "value": 1}, "value": 0.2}
  }
}
```
![visualization](https://user-images.githubusercontent.com/15064365/205465616-9757cc9b-ed91-4a40-9297-a4d82cc2ceb4.png)

[Editor link](https://vega.github.io/editor/#/url/vega-lite/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykBaADZ04JAKyUAVhDYA7EABoQAEySYUqUMSSCGcCGgDaoWQwRM4AJzQBGJWUtsGONCAAeikNt1w0ABkobAF8FEzMLa1Q7EAcnF3QAT09vPX9KADYQsPMrW3tHZ1cAL2SdVNQAgE4skFMcyIAmfLjXDyUU3wrKAHYauoi0JpiC+JAk9rLOgIa+8NzUIdjC9BKJn1tA2fq0AGZm5fdS9a7M0Nq5yL3hlsSj8oDgs-75q6XR1a9JtJmAXRCQHBISxIBAGVDGWogzogKDCKAAazunQhz0a+1GHi2A1QrxGxRAQR+SggcEEcCgmDQoEwCRw0JwbBoskpSjgsigbGUTLIYMMhyUHMEbGsf0JSmQlkR6CYQM8bI5XNkZCph00IAAZjRScpXKiCUokmrNdrXB1PDS6a4AI4MJDMuhqGikfUwthCyKgY2CHXoN4utiAqB0Q2gDmyLmYdjyNWA4EIVywmgIpG2f5mrozIJBIA)

The initial bar selections are specified by providing a `value` to the `click` selection parameter.  Vega-Lite produces the following Vega dataset to store this initial selection information:

```json
    {
      "name": "click_store",
      "values": [
        {
          "unit": "",
          "fields": [
            {"field": "number", "channel": "x", "type": "E"},
            {"field": "group", "channel": "color", "type": "E"}
          ],
          "values": [2, "x"]
        },
        {
          "unit": "",
          "fields": [
            {"field": "number", "channel": "x", "type": "E"},
            {"field": "group", "channel": "color", "type": "E"}
          ],
          "values": [3, "z"]
        }
      ]
    }
```
Because the x-axis data type is numeric and the color data type is categorical, this dataset includes mixed type arrays (e.g. `[2, "x"]`).

When a JSON dataset with mixed type arrays is imported into an Arrow Record batch, this mixed type array is homogenized to `["2", "x"]`.  Prior to this PR, `pre_transform_spec` would round trip all inline JSON datasets through arrow record batches, which would result in the pre-transformed spec including the homogenized arrays. In this particular example, replacing the numbers 2 and 3 with the strings "2" and "3" breaks the indented behavior of initializing the chart's selection.

This PR avoids round-tripping inline datasets through Arrow if there are no transforms defined on the dataset.