### PR TITLE
Update pre_transform_spec to handle selection datasets with datetime strings

### DIFF
--- a/vegafusion-rt-datafusion/src/lib.rs
+++ b/vegafusion-rt-datafusion/src/lib.rs
@@ -14,6 +14,7 @@ extern crate log;
 
 pub mod data;
 pub mod expression;
+pub mod pre_transform;
 pub mod signal;
 pub mod sql;
 pub mod task_graph;

--- a/vegafusion-rt-datafusion/src/pre_transform/destringify_selection_datetimes.rs
+++ b/vegafusion-rt-datafusion/src/pre_transform/destringify_selection_datetimes.rs
@@ -1,0 +1,110 @@
+use crate::expression::compiler::builtin_functions::date_time::str_to_timestamptz::parse_datetime;
+use serde_json::Value;
+use std::collections::HashSet;
+use vegafusion_core::error::Result;
+use vegafusion_core::spec::chart::{ChartSpec, MutChartVisitor};
+use vegafusion_core::spec::data::DataSpec;
+use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
+use vegafusion_core::spec::transform::TransformSpec;
+
+/// Post pre-transform transformation that detects the use of datetime strings in
+/// Vega-Lite style selection "_store" datasets, and adds a transform to convert
+/// them to UTC milliseconds.
+pub fn destringify_selection_datetimes(spec: &mut ChartSpec) -> Result<()> {
+    let mut visitor = DestringifySelectionDatetimesVisitor::new();
+    spec.walk_mut(&mut visitor)?;
+    Ok(())
+}
+
+struct DestringifySelectionDatetimesVisitor {}
+
+impl DestringifySelectionDatetimesVisitor {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl MutChartVisitor for DestringifySelectionDatetimesVisitor {
+    fn visit_data(&mut self, data: &mut DataSpec, _scope: &[u32]) -> Result<()> {
+        if let Some(Value::Array(values)) = &data.values {
+            if let Some(Value::Object(value0)) = values.get(0) {
+                let columns: HashSet<_> = value0.keys().cloned().collect();
+                let store_columns: HashSet<_> = vec!["unit", "fields", "values"]
+                    .iter()
+                    .map(|f| f.to_string())
+                    .collect();
+                if store_columns == columns && data.transform.is_empty() {
+                    // We have a selection store dataset with no transforms
+                    // Extract the values array
+                    if let Value::Array(values) = &value0["values"] {
+                        if let Some(Value::Array(values)) = values.get(0) {
+                            // Nested array, as in the case of an interval selection
+                            let is_date_str: Vec<_> = values
+                                .iter()
+                                .map(|value| {
+                                    matches!(value, Value::String(value) if parse_datetime(value, &Some(chrono_tz::UTC)).is_some())
+                                })
+                                .collect();
+
+                            // Check whether we have at least one datestring to convert
+                            if !is_date_str.is_empty() && is_date_str.iter().any(|v| *v) {
+                                let exprs: Vec<_> = is_date_str
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(i, is_date_str)| {
+                                        if *is_date_str {
+                                            format!("toDate(datum.values[0][{}])", i)
+                                        } else {
+                                            format!("datum.values[0][{}]", i)
+                                        }
+                                    })
+                                    .collect();
+                                let exprs_csv = exprs.join(", ");
+                                let formula_expr = format!("[[{}]]", exprs_csv);
+                                data.transform
+                                    .push(TransformSpec::Formula(FormulaTransformSpec {
+                                        expr: formula_expr,
+                                        as_: "values".to_string(),
+                                        extra: Default::default(),
+                                    }));
+                            }
+                        } else {
+                            // Non-nested array, as in the case of point selection
+                            // Build expression strings for each element of values
+                            let is_date_str: Vec<_> = values
+                                .iter()
+                                .map(|value| {
+                                    matches!(value, Value::String(value) if parse_datetime(value, &Some(chrono_tz::UTC)).is_some())
+                                })
+                                .collect();
+
+                            // Check whether we have at least one datestring to convert
+                            if !is_date_str.is_empty() && is_date_str.iter().any(|v| *v) {
+                                let exprs: Vec<_> = is_date_str
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(i, is_date_str)| {
+                                        if *is_date_str {
+                                            format!("toDate(datum.values[{}])", i)
+                                        } else {
+                                            format!("datum.values[{}]", i)
+                                        }
+                                    })
+                                    .collect();
+                                let exprs_csv = exprs.join(", ");
+                                let formula_expr = format!("[{}]", exprs_csv);
+                                data.transform
+                                    .push(TransformSpec::Formula(FormulaTransformSpec {
+                                        expr: formula_expr,
+                                        as_: "values".to_string(),
+                                        extra: Default::default(),
+                                    }));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/vegafusion-rt-datafusion/src/pre_transform/mod.rs
+++ b/vegafusion-rt-datafusion/src/pre_transform/mod.rs
@@ -1,0 +1,1 @@
+pub mod destringify_selection_datetimes;

--- a/vegafusion-rt-datafusion/src/task_graph/runtime.rs
+++ b/vegafusion-rt-datafusion/src/task_graph/runtime.rs
@@ -12,6 +12,7 @@ use vegafusion_core::error::{Result, ResultWithContext, ToExternalError, VegaFus
 use vegafusion_core::task_graph::task_value::TaskValue;
 
 use crate::data::dataset::VegaFusionDataset;
+use crate::pre_transform::destringify_selection_datetimes::destringify_selection_datetimes;
 use crate::task_graph::cache::VegaFusionCache;
 use crate::task_graph::task::TaskCall;
 use crate::task_graph::timezone::RuntimeTzConfig;
@@ -333,6 +334,9 @@ impl TaskGraphRuntime {
                 }
             }
         }
+
+        // Destringify datetime strings in selection store datasets
+        destringify_selection_datetimes(&mut spec)?;
 
         // Build warnings
         let mut warnings: Vec<PreTransformSpecWarning> = Vec::new();

--- a/vegafusion-rt-datafusion/tests/specs/pre_transform/datetime_strings_in_selection_stores.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/pre_transform/datetime_strings_in_selection_stores.vg.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "data": [
+    {
+      "name": "source_0",
+      "url": "data/seattle-weather.csv",
+      "format": {"type": "csv", "parse": {"date": "date"}},
+      "transform": [
+        {
+          "field": "date",
+          "type": "timeunit",
+          "units": ["year", "month"],
+          "as": ["yearmonth_date", "yearmonth_date_end"]
+        },
+        {
+          "type": "aggregate",
+          "groupby": ["yearmonth_date", "yearmonth_date_end", "weather"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "stack",
+          "groupby": ["yearmonth_date"],
+          "field": "__count",
+          "sort": {"field": ["weather"], "order": ["descending"]},
+          "as": ["__count_start", "__count_end"],
+          "offset": "zero"
+        },
+        {
+          "type": "filter",
+          "expr": "(isDate(datum[\"yearmonth_date\"]) || (isValid(datum[\"yearmonth_date\"]) && isFinite(+datum[\"yearmonth_date\"])))"
+        }
+      ]
+    },
+    {
+      "name": "click_store",
+      "values": [
+        {
+          "unit": "",
+          "fields": [
+            {"field": "yearmonth_date", "channel": "x", "type": "E"},
+            {"field": "weather", "channel": "color", "type": "E"}
+          ],
+          "values": ["2014-01-01T00:00:00", "sun"]
+        },
+        {
+          "unit": "",
+          "fields": [
+            {"field": "yearmonth_date", "channel": "x", "type": "E"},
+            {"field": "weather", "channel": "color", "type": "E"}
+          ],
+          "values": ["2013-11-01T00:00:00", "rain"]
+        }
+      ]
+    },
+    {
+      "name": "drag_store",
+      "values": [
+        {
+          "unit": "",
+          "fields": [{"field": "yearmonth_date", "channel": "x", "type": "R"}],
+          "values": [["2012-11-27T06:58:03.000", "2013-06-04T06:38:51.000"]]
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "rect",
+      "style": ["bar"],
+      "interactive": true,
+      "from": {"data": "source_0"},
+      "encode": {
+        "update": {
+          "fill": {"scale": "color", "field": "weather"},
+          "opacity": [
+            {
+              "test": "!length(data(\"click_store\")) || vlSelectionTest(\"click_store\", datum)",
+              "value": 1
+            },
+            {
+              "test": "!length(data(\"drag_store\")) || vlSelectionTest(\"drag_store\", datum)",
+              "value": 1
+            },
+            {"value": 0.3}
+          ],
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"Month of the year: \" + (timeFormat(datum[\"yearmonth_date\"], timeUnitSpecifier([\"year\",\"month\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\")) + \"; Weather type: \" + (isValid(datum[\"weather\"]) ? datum[\"weather\"] : \"\"+datum[\"weather\"])"
+          },
+          "x2": {"scale": "x", "field": "yearmonth_date", "offset": 1},
+          "x": {"scale": "x", "field": "yearmonth_date_end"},
+          "y": {"scale": "y", "field": "__count_end"},
+          "y2": {"scale": "y", "field": "__count_start"}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "time",
+      "domain": {
+        "data": "source_0",
+        "fields": ["yearmonth_date", "yearmonth_date_end"]
+      },
+      "range": [0, {"signal": "width"}]
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "data": "source_0",
+        "fields": ["__count_start", "__count_end"]
+      },
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": ["sun", "fog", "drizzle", "rain", "snow"],
+      "range": ["#e7ba52", "#c7c7c7", "#aec7e8", "#1f77b4", "#9467bd"]
+    }
+  ]
+}

--- a/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
+++ b/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
@@ -4,7 +4,6 @@ mod tests {
     use std::fs;
     use vegafusion_core::proto::gen::services::pre_transform_spec_result;
     use vegafusion_core::spec::chart::ChartSpec;
-    use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
     use vegafusion_core::spec::transform::TransformSpec;
     use vegafusion_rt_datafusion::task_graph::runtime::TaskGraphRuntime;
 

--- a/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
+++ b/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
@@ -1,0 +1,64 @@
+#[cfg(test)]
+mod tests {
+    use crate::crate_dir;
+    use std::fs;
+    use vegafusion_core::proto::gen::services::pre_transform_spec_result;
+    use vegafusion_core::spec::chart::ChartSpec;
+    use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
+    use vegafusion_core::spec::transform::TransformSpec;
+    use vegafusion_rt_datafusion::task_graph::runtime::TaskGraphRuntime;
+
+    #[tokio::test]
+    async fn test_destringify_selection_datasets() {
+        // Load spec
+        let spec_path = format!(
+            "{}/tests/specs/pre_transform/datetime_strings_in_selection_stores.vg.json",
+            crate_dir()
+        );
+        let spec_str = fs::read_to_string(spec_path).unwrap();
+
+        // Initialize task graph runtime
+        let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
+
+        let result = runtime
+            .pre_transform_spec(&spec_str, "UTC", &None, None, Default::default())
+            .await
+            .unwrap();
+
+        match result.result.unwrap() {
+            pre_transform_spec_result::Result::Response(response) => {
+                let chart_spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
+
+                let data1 = &chart_spec.data[1];
+                assert_eq!(data1.name.as_str(), "click_store");
+                assert_eq!(data1.transform.len(), 1);
+                if let TransformSpec::Formula(formula) = &data1.transform[0] {
+                    assert_eq!(formula.expr, "[toDate(datum.values[0]), datum.values[1]]");
+                } else {
+                    panic!("Unexpected transform")
+                }
+
+                let data2 = &chart_spec.data[2];
+                assert_eq!(data2.name.as_str(), "drag_store");
+                assert_eq!(data2.transform.len(), 1);
+                if let TransformSpec::Formula(formula) = &data2.transform[0] {
+                    assert_eq!(
+                        formula.expr,
+                        "[[toDate(datum.values[0][0]), toDate(datum.values[0][1])]]"
+                    );
+                } else {
+                    panic!("Unexpected transform")
+                }
+            }
+            pre_transform_spec_result::Result::Error(err) => {
+                panic!("Unexpected pre_transform_spec error: {:?}", err);
+            }
+        }
+    }
+}
+
+fn crate_dir() -> String {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .display()
+        .to_string()
+}


### PR DESCRIPTION
This PR adds support to pre_transform_spec for handling Vega-Lite style selection store datasets that include datetime string.

Point selection example:
```json
    {
      "name": "click_store",
      "values": [
        {
          "unit": "",
          "fields": [
            {"field": "yearmonth_date", "channel": "x", "type": "E"},
            {"field": "weather", "channel": "color", "type": "E"}
          ],
          "values": ["2014-01-01T00:00:00", "sun"]
        },
        {
          "unit": "",
          "fields": [
            {"field": "yearmonth_date", "channel": "x", "type": "E"},
            {"field": "weather", "channel": "color", "type": "E"}
          ],
          "values": ["2013-11-01T00:00:00", "rain"]
        }
      ]
    },
```

Interval selection example:
```json
    {
      "name": "drag_store",
      "values": [
        {
          "unit": "",
          "fields": [{"field": "yearmonth_date", "channel": "x", "type": "R"}],
          "values": [["2012-11-27T06:58:03.000", "2013-06-04T06:38:51.000"]]
        }
      ]
    },
```

Vega's `VlSelectionTest` function doesn't handle datetime strings, instead expecting timestamp values to be provided as utc millisecond integers.  Since it's potentially convenient to specify datetimes as strings (for the sake of timezone handling),  this PR updates VegaFusion's pre_transform_spec logic to detect that datetime strings are in use and insert an explicit `formula` transform to convert them to UTC milliseconds using the Vega `toDate` function.

With this PR, the two examples above are converted to the following:

Point selection
```json
    {
      "name": "click_store",
      "values": [
        {
          "unit": "",
          "fields": [
            {
              "field": "yearmonth_date",
              "channel": "x",
              "type": "E"
            },
            {
              "field": "weather",
              "channel": "color",
              "type": "E"
            }
          ],
          "values": [
            "2014-01-01T00:00:00",
            "sun"
          ]
        },
        {
          "unit": "",
          "fields": [
            {
              "field": "yearmonth_date",
              "channel": "x",
              "type": "E"
            },
            {
              "field": "weather",
              "channel": "color",
              "type": "E"
            }
          ],
          "values": [
            "2013-11-01T00:00:00",
            "rain"
          ]
        }
      ],
      "transform": [
        {
          "type": "formula",
          "expr": "[toDate(datum.values[0]), datum.values[1]]",
          "as": "values"
        }
      ]
    }
```

Interval selection:
```json
    {
      "name": "drag_store",
      "values": [
        {
          "unit": "",
          "fields": [
            {
              "field": "yearmonth_date",
              "channel": "x",
              "type": "R"
            }
          ],
          "values": [
            [
              "2012-11-27T06:58:03.000",
              "2013-06-04T06:38:51.000"
            ]
          ]
        }
      ],
      "transform": [
        {
          "type": "formula",
          "expr": "[[toDate(datum.values[0][0]), toDate(datum.values[0][1])]]",
          "as": "values"
        }
      ]
    },
```
