### PR TITLE
Add support for VlSelectionTest for providing comparison scalars as datetime strings

### DIFF
--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/data_fn.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/data_fn.rs
@@ -6,11 +6,17 @@
  * Please consult the license documentation provided alongside
  * this program the details of the active license.
  */
+use crate::task_graph::timezone::RuntimeTzConfig;
 use datafusion::logical_plan::{DFSchema, Expr};
 use vegafusion_core::data::table::VegaFusionTable;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::expression::Expression;
 
-pub fn data_fn(table: &VegaFusionTable, _args: &[Expression], _schema: &DFSchema) -> Result<Expr> {
+pub fn data_fn(
+    table: &VegaFusionTable,
+    _args: &[Expression],
+    _schema: &DFSchema,
+    _tz_config: &RuntimeTzConfig,
+) -> Result<Expr> {
     Ok(Expr::Literal(table.to_scalar_value()?))
 }

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/vl_selection_resolve.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/vl_selection_resolve.rs
@@ -23,6 +23,7 @@ use crate::expression::compiler::builtin_functions::data::vl_selection_test::{
     SelectionRow, SelectionType,
 };
 
+use crate::task_graph::timezone::RuntimeTzConfig;
 use vegafusion_core::proto::gen::{
     expression::expression::Expr as ProtoExpr, expression::Expression, expression::Literal,
 };
@@ -63,6 +64,7 @@ pub fn vl_selection_resolve_fn(
     table: &VegaFusionTable,
     args: &[Expression],
     _schema: &DFSchema,
+    _tz_config: &RuntimeTzConfig,
 ) -> Result<Expr> {
     // Validate args and get operation
     let _op = parse_args(args)?;

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/vl_selection_test.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/data/vl_selection_test.rs
@@ -289,7 +289,13 @@ impl FieldSpec {
                 };
                 cast_to(ms_expr, field_type, schema)
             }
-            _ => cast_to(lit(scalar), field_type, schema),
+            _ => {
+                if is_numeric_datatype(field_type) && !is_numeric_datatype(&scalar.get_datatype()) {
+                    cast_to(lit(scalar), field_type, schema)
+                } else {
+                    Ok(lit(scalar))
+                }
+            }
         }
     }
 }

--- a/vegafusion-rt-datafusion/tests/specs/pre_transform/datetime_strings_in_selection_stores.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/pre_transform/datetime_strings_in_selection_stores.vg.json
@@ -11,7 +11,12 @@
           "type": "timeunit",
           "units": ["year", "month"],
           "as": ["yearmonth_date", "yearmonth_date_end"]
-        },
+        }
+      ]
+    }, {
+      "name": "data_0",
+      "source":  "source_0",
+      "transform": [
         {
           "type": "aggregate",
           "groupby": ["yearmonth_date", "yearmonth_date_end", "weather"],
@@ -63,6 +68,26 @@
           "values": [["2012-11-27T06:58:03.000", "2013-06-04T06:38:51.000"]]
         }
       ]
+    },
+    {
+      "name": "click_selected",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "!length(data(\"click_store\")) || vlSelectionTest(\"click_store\", datum)"
+        }
+      ]
+    },
+    {
+      "name": "drag_selected",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "!length(data(\"drag_store\")) || vlSelectionTest(\"drag_store\", datum)"
+        }
+      ]
     }
   ],
   "marks": [
@@ -71,7 +96,7 @@
       "type": "rect",
       "style": ["bar"],
       "interactive": true,
-      "from": {"data": "source_0"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "fill": {"scale": "color", "field": "weather"},

--- a/vegafusion-rt-datafusion/tests/specs/pre_transform/datetime_strings_in_selection_stores.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/pre_transform/datetime_strings_in_selection_stores.vg.json
@@ -65,13 +65,13 @@
         {
           "unit": "",
           "fields": [{"field": "yearmonth_date", "channel": "x", "type": "R"}],
-          "values": [["2012-11-27T06:58:03.000", "2013-06-04T06:38:51.000"]]
+          "values": [["2014-01-01T00:00:00", "2013-11-01T00:00:00"]]
         }
       ]
     },
     {
       "name": "click_selected",
-      "source": "source_0",
+      "source": "data_0",
       "transform": [
         {
           "type": "filter",
@@ -81,7 +81,7 @@
     },
     {
       "name": "drag_selected",
-      "source": "source_0",
+      "source": "data_0",
       "transform": [
         {
           "type": "filter",

--- a/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
+++ b/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
@@ -28,19 +28,19 @@ mod tests {
             pre_transform_spec_result::Result::Response(response) => {
                 let chart_spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
 
-                let data1 = &chart_spec.data[1];
-                assert_eq!(data1.name.as_str(), "click_store");
-                assert_eq!(data1.transform.len(), 1);
-                if let TransformSpec::Formula(formula) = &data1.transform[0] {
+                let click_store = &chart_spec.data[2];
+                assert_eq!(click_store.name.as_str(), "click_store");
+                assert_eq!(click_store.transform.len(), 1);
+                if let TransformSpec::Formula(formula) = &click_store.transform[0] {
                     assert_eq!(formula.expr, "[toDate(datum.values[0]), datum.values[1]]");
                 } else {
                     panic!("Unexpected transform")
                 }
 
-                let data2 = &chart_spec.data[2];
-                assert_eq!(data2.name.as_str(), "drag_store");
-                assert_eq!(data2.transform.len(), 1);
-                if let TransformSpec::Formula(formula) = &data2.transform[0] {
+                let drag_store = &chart_spec.data[3];
+                assert_eq!(drag_store.name.as_str(), "drag_store");
+                assert_eq!(drag_store.transform.len(), 1);
+                if let TransformSpec::Formula(formula) = &drag_store.transform[0] {
                     assert_eq!(
                         formula.expr,
                         "[[toDate(datum.values[0][0]), toDate(datum.values[0][1])]]"

--- a/vegafusion-rt-datafusion/tests/test_selection.rs
+++ b/vegafusion-rt-datafusion/tests/test_selection.rs
@@ -18,6 +18,7 @@ use vegafusion_core::data::table::VegaFusionTable;
 use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_rt_datafusion::expression::compiler::config::CompilationConfig;
+use vegafusion_rt_datafusion::task_graph::timezone::RuntimeTzConfig;
 
 fn make_brush_r(ranges: &Vec<Vec<(&str, &str, [f64; 2])>>, typ: &str) -> VegaFusionTable {
     let mut rows: Vec<Value> = Vec::new();
@@ -120,6 +121,10 @@ pub fn check_vl_selection_test(
         data_scope: vec![("brush".to_string(), brush_dataset)]
             .into_iter()
             .collect(),
+        tz_config: Some(RuntimeTzConfig {
+            local_tz: chrono_tz::UTC,
+            default_input_tz: chrono_tz::UTC,
+        }),
         ..Default::default()
     };
     let eq_config = Default::default();


### PR DESCRIPTION
This PR updates the implementation of VlSelectionTest to support comparison values (either enum values for a point selection or range values for an interval selection) as datetime strings.

Combined with https://github.com/vegafusion/vegafusion/pull/182, this makes it possible for a full `pre_transform_spec` workflow to support datetime strings in selection stores, whether the selection is used on the server the client or both.