### PR TITLE
Add median support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "15.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f#9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6#45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "15.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f#9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6#45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 dependencies = [
  "arrow",
  "chrono",
@@ -1018,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "15.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f#9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6#45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "15.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f#9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6#45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "15.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f#9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6#45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1074,7 +1074,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "15.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f#9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6#45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "15.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f#9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6#45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 dependencies = [
  "arrow-schema",
  "datafusion-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,6 +2042,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +2864,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -2870,6 +2881,52 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1c03e9011a8c59716ad13115550469e081e2e9892656b0ba6a47c907921894"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db161043fcfae3bdf30768bb1fa833853cd55ddf2411b1acb03e0c72bf86a9ea"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "http",
+ "hyper",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "task-local-extensions",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09bbcb5003282bcb688f0bae741b278e9c7e8f378f561522c9806c58e075d9b"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand",
 ]
 
 [[package]]
@@ -3349,6 +3406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
+name = "task-local-extensions"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4167afbec18ae012de40f8cf1b9bf48420abb390678c34821caa07d924941cc4"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,6 +3830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,6 +3991,8 @@ dependencies = [
  "prost-types",
  "regex",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "rgb",
  "rstest",
  "serde",

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -37,8 +37,10 @@ default_features = false
 features = [ "ipc", "json"]
 
 [dependencies.datafusion-common]
-git = "https://github.com/apache/arrow-datafusion.git"
-rev = "9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+# Use custom branch that is version 15.0.0 with median
+# fix cherry picked
+git = "https://github.com/jonmmease/arrow-datafusion.git"
+rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 
 [dependencies.pyo3]
 version = "0.17.1"

--- a/vegafusion-core/src/spec/transform/aggregate.rs
+++ b/vegafusion-core/src/spec/transform/aggregate.rs
@@ -100,6 +100,7 @@ impl TransformSpecTrait for AggregateTransformSpec {
                     | Variancep
                     | Stdev
                     | Stdevp
+                    | Median
             ) {
                 // Unsupported aggregation op
                 return false;

--- a/vegafusion-core/src/spec/transform/joinaggregate.rs
+++ b/vegafusion-core/src/spec/transform/joinaggregate.rs
@@ -51,6 +51,7 @@ impl TransformSpecTrait for JoinAggregateTransformSpec {
                     | Variancep
                     | Stdev
                     | Stdevp
+                    | Median
             ) {
                 // Unsupported aggregation op
                 return false;

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -413,6 +413,14 @@ impl<'a> InputVarsChartVisitor<'a> {
 
             if let Some(MarkFacetSpec { data, .. }) = &from.facet {
                 let data_var = Variable::new_data(data);
+                // A facet data reference does not have access to datasets defined in the same scope,
+                // so drop the final scope entry to simulate the reference being one level above
+                let scope = if scope.len() > 0 {
+                    &scope[..scope.len() - 1]
+                } else {
+                    scope
+                };
+
                 let resolved = self.task_scope.resolve_scope(&data_var, scope)?;
                 self.input_vars.insert((data_var, resolved.scope));
             }

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -415,7 +415,7 @@ impl<'a> InputVarsChartVisitor<'a> {
                 let data_var = Variable::new_data(data);
                 // A facet data reference does not have access to datasets defined in the same scope,
                 // so drop the final scope entry to simulate the reference being one level above
-                let scope = if scope.len() > 0 {
+                let scope = if !scope.is_empty() {
                     &scope[..scope.len() - 1]
                 } else {
                     scope

--- a/vegafusion-rt-datafusion/Cargo.toml
+++ b/vegafusion-rt-datafusion/Cargo.toml
@@ -68,12 +68,12 @@ version = "1.0.137"
 features = [ "derive",]
 
 [dependencies.datafusion]
-git = "https://github.com/apache/arrow-datafusion.git"
-rev = "9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+git = "https://github.com/jonmmease/arrow-datafusion.git"
+rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 
 [dependencies.datafusion-expr]
-git = "https://github.com/apache/arrow-datafusion.git"
-rev = "9bee14ebd39dacbb66a9b1f34cd6494bc6a6be3f"
+git = "https://github.com/jonmmease/arrow-datafusion.git"
+rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
 
 [dependencies.tokio]
 version = "1.18.1"

--- a/vegafusion-rt-datafusion/Cargo.toml
+++ b/vegafusion-rt-datafusion/Cargo.toml
@@ -36,6 +36,8 @@ env_logger = "0.9.0"
 ordered-float = "3.4.0"
 uuid = { version = "^1.2", features = ["v4"] }
 lock_api = "^0.4.8"
+reqwest-retry = "0.2.1"
+reqwest-middleware = "0.2.0"
 
 [dev-dependencies]
 futures = "0.3.21"

--- a/vegafusion-rt-datafusion/src/transform/aggregate.rs
+++ b/vegafusion-rt-datafusion/src/transform/aggregate.rs
@@ -180,6 +180,12 @@ pub fn make_aggr_expr(
         AggregateOp::Min => min(numeric_column()),
         AggregateOp::Max => max(numeric_column()),
         AggregateOp::Sum => sum(numeric_column()),
+        AggregateOp::Median => Expr::AggregateFunction {
+            fun: aggregate_function::AggregateFunction::Median,
+            distinct: false,
+            args: vec![numeric_column()],
+            filter: None,
+        },
         AggregateOp::Variance => Expr::AggregateFunction {
             fun: aggregate_function::AggregateFunction::Variance,
             distinct: false,

--- a/vegafusion-rt-datafusion/tests/specs/vega/barley.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vega/barley.comm_plan.json
@@ -21,7 +21,7 @@
       "scope": []
     },
     {
-      "namespace": "data",v
+      "namespace": "data",
       "name": "barley_yscale_domain_variety_0",
       "scope": []
     }

--- a/vegafusion-rt-datafusion/tests/specs/vega/barley.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vega/barley.comm_plan.json
@@ -12,7 +12,17 @@
     },
     {
       "namespace": "data",
+      "name": "barley_gscale_domain_site",
+      "scope": []
+    },
+    {
+      "namespace": "data",
       "name": "barley_xscale_domain_yield",
+      "scope": []
+    },
+    {
+      "namespace": "data",v
+      "name": "barley_yscale_domain_variety_0",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vega/layout-wrap.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vega/layout-wrap.comm_plan.json
@@ -14,6 +14,11 @@
       "namespace": "data",
       "name": "barley_xscale_domain_yield",
       "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "barley_yscale_domain_variety",
+      "scope": []
     }
   ],
   "client_to_server": []

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/concat_weather.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/concat_weather.comm_plan.json
@@ -12,7 +12,32 @@
     },
     {
       "namespace": "data",
-      "name": "_server_data_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_concat_0_x_domain_month_date",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_concat_0_y_domain_mean_precipitation",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_concat_1_x_domain_month_date",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_concat_1_y_domain_median_precipitation",
       "scope": []
     },
     {

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/line_slope.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/line_slope.comm_plan.json
@@ -2,7 +2,22 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_color_domain_site",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_x_domain_year",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_y_domain_median_yield",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_barley.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_barley.comm_plan.json
@@ -2,7 +2,27 @@
   "server_to_client": [
     {
       "namespace": "data",
+      "name": "data_2_trellis_barley_color_domain_year",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_trellis_barley_x_domain_median_yield",
+      "scope": []
+    },
+    {
+      "namespace": "data",
       "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_trellis_barley_y_domain_variety",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "trellis_barley_facet_domain",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_barley_independent.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_barley_independent.comm_plan.json
@@ -2,7 +2,22 @@
   "server_to_client": [
     {
       "namespace": "data",
+      "name": "data_2_trellis_barley_color_domain_year",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_trellis_barley_x_domain_median_yield",
+      "scope": []
+    },
+    {
+      "namespace": "data",
       "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_trellis_barley_y_domain_variety",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_barley_layer_median.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/trellis_barley_layer_median.comm_plan.json
@@ -2,7 +2,32 @@
   "server_to_client": [
     {
       "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_trellis_barley_color_domain_year",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
       "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_trellis_barley_y_domain_variety",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "trellis_barley_row_domain",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -1026,6 +1026,7 @@ mod test_image_comparison_agg {
             AggregateOpSpec::Variancep,
             AggregateOpSpec::Stdev,
             AggregateOpSpec::Stdevp,
+            AggregateOpSpec::Median,
         )]
         agg: AggregateOpSpec,
 

--- a/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
@@ -181,43 +181,45 @@ fn test_bin_aggregate() {
     );
 }
 
-// /// Test that the "as" column in a aggregate transform can have the same name as a Field,
-// /// then use the overwritten column in a filter expression.
-// /// Blocked on https://github.com/apache/arrow-datafusion/issues/1411
-// #[test]
-// fn test_aggregate_overwrite() {
-//     let dataset = vega_json_dataset("penguins");
-//     let aggregate_spec: AggregateTransformSpec = serde_json::from_value(serde_json::json!(
-//             {
-//                 "groupby": ["Species"],
-//                 "fields": ["Beak Depth (mm)"],
-//                 "op": ["max"],
-//                 "as": ["Beak Depth (mm)"]
-//             }
-//         )).unwrap();
-//     let filter_spec: FilterTransformSpec = serde_json::from_value(serde_json::json!(
-//             {
-//                 "expr": "isFinite(datum['Beak Depth (mm)'])",
-//             }
-//         )).unwrap();
-//
-//     let transform_specs = vec![
-//         TransformSpec::Aggregate(aggregate_spec),
-//         TransformSpec::Filter(filter_spec)
-//     ];
-//
-//     let comp_config = Default::default();
-//
-//     // Order of grouped rows is not defined, so set row_order to false
-//     let eq_config = TablesEqualConfig {
-//         row_order: false,
-//         ..Default::default()
-//     };
-//
-//     check_transform_evaluation(
-//         &dataset,
-//         transform_specs.as_slice(),
-//         &comp_config,
-//         &eq_config,
-//     );
-// }
+/// Test that the "as" column in a aggregate transform can have the same name as a Field,
+/// then use the overwritten column in a filter expression.
+/// Originally blocked on https://github.com/apache/arrow-datafusion/issues/1411
+#[test]
+fn test_aggregate_overwrite() {
+    let dataset = vega_json_dataset("penguins");
+    let aggregate_spec: AggregateTransformSpec = serde_json::from_value(serde_json::json!(
+        {
+            "groupby": ["Species"],
+            "fields": ["Beak Depth (mm)"],
+            "op": ["max"],
+            "as": ["Beak Depth (mm)"]
+        }
+    ))
+    .unwrap();
+    let filter_spec: FilterTransformSpec = serde_json::from_value(serde_json::json!(
+        {
+            "expr": "isFinite(datum['Beak Depth (mm)'])",
+        }
+    ))
+    .unwrap();
+
+    let transform_specs = vec![
+        TransformSpec::Aggregate(aggregate_spec),
+        TransformSpec::Filter(filter_spec),
+    ];
+
+    let comp_config = Default::default();
+
+    // Order of grouped rows is not defined, so set row_order to false
+    let eq_config = TablesEqualConfig {
+        row_order: false,
+        ..Default::default()
+    };
+
+    check_transform_evaluation(
+        &dataset,
+        transform_specs.as_slice(),
+        &comp_config,
+        &eq_config,
+    );
+}

--- a/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
@@ -18,6 +18,7 @@ use util::equality::TablesEqualConfig;
 use rstest::rstest;
 use vegafusion_core::spec::transform::aggregate::{AggregateOpSpec, AggregateTransformSpec};
 use vegafusion_core::spec::transform::bin::{BinExtent, BinTransformSpec};
+use vegafusion_core::spec::transform::filter::FilterTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_core::spec::values::{Field, SignalExpressionSpec};
 
@@ -36,6 +37,7 @@ mod test_aggregate_single {
         case(AggregateOpSpec::Average),
         case(AggregateOpSpec::Min),
         case(AggregateOpSpec::Max),
+        case(AggregateOpSpec::Median),
     )]
     fn test(op: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");
@@ -84,6 +86,7 @@ mod test_aggregate_multi {
         case(AggregateOpSpec::Average, AggregateOpSpec::Mean),
         case(AggregateOpSpec::Min, AggregateOpSpec::Average),
         case(AggregateOpSpec::Max, AggregateOpSpec::Min),
+        case(AggregateOpSpec::Median, AggregateOpSpec::Average),
     )]
     fn test(op1: AggregateOpSpec, op2: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");


### PR DESCRIPTION
This PR adds support for evaluating median aggregations in VegaFusion.

This is done by buiding VegaFusion against a custom branch of DataFusion. This branch is based on DataFusion 15 (the last official release) with a [median bug fix](https://github.com/apache/arrow-datafusion/pull/4488) cherry picked on top of it.

As an aside, going forward I think it makes sense to stick to using major version releases of DataFusion, with any specific bug fixes we need cherry picked on top.

----

Separately, to help with some test flakiness update the data tasks to retry get requests using [`reqwest_retry`](https://docs.rs/reqwest-retry/latest/reqwest_retry/).