### PR TITLE
Maintain interactivity of chart specifications produced by pre_transform_spec

### DIFF
--- a/python/vegafusion/tests/test_pretransform.py
+++ b/python/vegafusion/tests/test_pretransform.py
@@ -909,8 +909,11 @@ def test_date32_pre_transform_dataset():
         spec, ["data_0"], "America/New_York", default_input_tz="UTC", inline_datasets=dict(dates=dates_df)
     )
 
+    # Timestamps are always in UTC, so we're checking that they would convert to midnight local time
     assert list(output_ds.date_col) == [
-        "2022-01-01T00:00:00.000", "2022-01-02T00:00:00.000", "2022-01-03T00:00:00.000"
+        pd.Timestamp('2022-01-01 05:00:00'),
+        pd.Timestamp('2022-01-02 05:00:00'),
+        pd.Timestamp('2022-01-03 05:00:00')
     ]
 
 
@@ -965,7 +968,7 @@ def test_nat_values():
 
     dataset = datasets[0]
     assert dataset.to_dict("records")[0] == {
-        'NULL_TEST': '2011-03-01T00:00:00.000',
+        'NULL_TEST': pd.Timestamp('2011-03-01 00:00:00'),
         'ORDER_DATE': Timestamp('2011-03-01 00:00:00'),
         'SALES': 457.568,
         'SALES_end': 457.568,

--- a/vegafusion-core/src/planning/plan.rs
+++ b/vegafusion-core/src/planning/plan.rs
@@ -15,6 +15,7 @@ use crate::planning::stitch::{stitch_specs, CommPlan};
 use crate::planning::stringify_local_datetimes::stringify_local_datetimes;
 use crate::planning::unsupported_data_warning::add_unsupported_data_warnings;
 use crate::spec::chart::ChartSpec;
+use crate::task_graph::graph::ScopedVariable;
 
 #[derive(Clone, Debug)]
 pub enum PlannerWarnings {
@@ -38,6 +39,8 @@ pub struct PlannerConfig {
     pub stringify_local_datetimes: bool,
     pub projection_pushdown: bool,
     pub extract_inline_data: bool,
+    pub allow_client_to_server_comms: bool,
+    pub client_only_vars: Vec<ScopedVariable>,
 }
 
 impl Default for PlannerConfig {
@@ -48,6 +51,8 @@ impl Default for PlannerConfig {
             stringify_local_datetimes: false,
             projection_pushdown: true,
             extract_inline_data: false,
+            allow_client_to_server_comms: true,
+            client_only_vars: Default::default(),
         }
     }
 }
@@ -82,9 +87,22 @@ impl SpecPlan {
         }
 
         let mut task_scope = client_spec.to_task_scope()?;
-
+        let input_client_spec = client_spec.clone();
         let mut server_spec = extract_server_data(&mut client_spec, &mut task_scope, config)?;
-        let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut client_spec)?;
+        let mut comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut client_spec)?;
+
+        if !config.allow_client_to_server_comms && !comm_plan.client_to_server.is_empty() {
+            // Client to server comms are not allowed and the initial planning
+            // pass included them. re-plan without
+            let mut config = config.clone();
+            config
+                .client_only_vars
+                .extend(comm_plan.client_to_server.clone());
+
+            client_spec = input_client_spec;
+            server_spec = extract_server_data(&mut client_spec, &mut task_scope, &config)?;
+            comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut client_spec)?;
+        }
 
         if config.split_url_data_nodes {
             split_data_url_nodes(&mut server_spec)?;

--- a/vegafusion-core/src/planning/stringify_local_datetimes.rs
+++ b/vegafusion-core/src/planning/stringify_local_datetimes.rs
@@ -70,7 +70,7 @@ pub fn stringify_local_datetimes(
     let mut visitor = CollectLocalTimeDataFieldsVisitor::try_new(
         visitor.local_datetime_fields,
         &server_to_client_datasets,
-        &server_spec,
+        server_spec,
     )?;
     server_spec.walk(&mut visitor)?;
     let local_datetime_fields = visitor.local_datetime_fields;
@@ -329,7 +329,7 @@ impl<'a> ChartVisitor for CollectLocalTimeDataFieldsVisitor<'a> {
         //       should be computed from the parent dataset, but we won't be able to do this
         //       in a visitor
         let local_columns =
-            data.local_datetime_columns_produced(&self.chart_spec, &self.task_scope, scope)?;
+            data.local_datetime_columns_produced(self.chart_spec, &self.task_scope, scope)?;
         let dataset_var: ScopedVariable = (Variable::new_data(&data.name), Vec::from(scope));
         if self.server_to_client_datasets.contains(&dataset_var) {
             match self.local_datetime_fields.entry(dataset_var) {

--- a/vegafusion-core/src/planning/stringify_local_datetimes.rs
+++ b/vegafusion-core/src/planning/stringify_local_datetimes.rs
@@ -19,6 +19,7 @@ use crate::spec::transform::TransformSpec;
 use crate::task_graph::graph::ScopedVariable;
 use crate::task_graph::scope::TaskScope;
 use itertools::sorted;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
 /// This planning phase converts select datetime columns from the default millisecond UTC
@@ -50,8 +51,10 @@ pub fn stringify_local_datetimes(
         .filter(|var| var.0.namespace == VariableNamespace::Data as i32)
         .collect();
 
-    let mut visitor =
-        CollectCandidateDatasetMapping::new(client_scope.clone(), server_to_client_datasets);
+    let mut visitor = CollectCandidateDatasetMapping::new(
+        client_scope.clone(),
+        server_to_client_datasets.clone(),
+    );
     client_spec.walk(&mut visitor)?;
     let candidate_dataset_mapping = visitor.candidate_dataset_mapping;
 
@@ -62,6 +65,14 @@ pub fn stringify_local_datetimes(
         candidate_dataset_mapping,
     );
     client_spec.walk(&mut visitor)?;
+
+    // Collect fields that are produced in datasets
+    let mut visitor = CollectLocalTimeDataFieldsVisitor::try_new(
+        visitor.local_datetime_fields,
+        &server_to_client_datasets,
+        &server_spec,
+    )?;
+    server_spec.walk(&mut visitor)?;
     let local_datetime_fields = visitor.local_datetime_fields;
 
     // Add formula transforms to server spec
@@ -285,6 +296,52 @@ fn get_local_datetime_fields(
         }
     } else {
         Default::default()
+    }
+}
+
+/// Visitor to collect local datetime columns produced by datasets
+struct CollectLocalTimeDataFieldsVisitor<'a> {
+    pub local_datetime_fields: HashMap<ScopedVariable, HashSet<String>>,
+    pub server_to_client_datasets: &'a HashSet<ScopedVariable>,
+    pub chart_spec: &'a ChartSpec,
+    pub task_scope: TaskScope,
+}
+
+impl<'a> CollectLocalTimeDataFieldsVisitor<'a> {
+    pub fn try_new(
+        local_datetime_fields: HashMap<ScopedVariable, HashSet<String>>,
+        server_to_client_datasets: &'a HashSet<ScopedVariable>,
+        chart_spec: &'a ChartSpec,
+    ) -> Result<Self> {
+        Ok(Self {
+            local_datetime_fields,
+            server_to_client_datasets,
+            chart_spec,
+            task_scope: chart_spec.to_task_scope()?,
+        })
+    }
+}
+
+impl<'a> ChartVisitor for CollectLocalTimeDataFieldsVisitor<'a> {
+    fn visit_data(&mut self, data: &DataSpec, scope: &[u32]) -> Result<()> {
+        // Add local datetime columns produced by the dataset.
+        // Note: This isn't quite complete, for derived datasets input_local_datetime_columns
+        //       should be computed from the parent dataset, but we won't be able to do this
+        //       in a visitor
+        let local_columns =
+            data.local_datetime_columns_produced(&self.chart_spec, &self.task_scope, scope)?;
+        let dataset_var: ScopedVariable = (Variable::new_data(&data.name), Vec::from(scope));
+        if self.server_to_client_datasets.contains(&dataset_var) {
+            match self.local_datetime_fields.entry(dataset_var) {
+                Entry::Occupied(mut v) => {
+                    v.get_mut().extend(local_columns);
+                }
+                Entry::Vacant(v) => {
+                    v.insert(local_columns.into_iter().collect());
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/vegafusion-core/src/planning/unsupported_data_warning.rs
+++ b/vegafusion-core/src/planning/unsupported_data_warning.rs
@@ -10,14 +10,15 @@ use crate::error::Result;
 use crate::planning::plan::{PlannerConfig, PlannerWarnings};
 use crate::spec::chart::{ChartSpec, ChartVisitor};
 use crate::spec::data::{DataSpec, DependencyNodeSupported};
+use crate::task_graph::scope::TaskScope;
 
 pub fn add_unsupported_data_warnings(
     chart_spec: &ChartSpec,
     config: &PlannerConfig,
     warnings: &mut Vec<PlannerWarnings>,
 ) -> Result<()> {
-    let mut visitor =
-        CollectUnsupportedDatasetsWarningsVisitor::new(config.extract_inline_data, warnings);
+    let task_scope = chart_spec.to_task_scope()?;
+    let mut visitor = CollectUnsupportedDatasetsWarningsVisitor::new(config, &task_scope, warnings);
     chart_spec.walk(&mut visitor)?;
     Ok(())
 }
@@ -25,14 +26,20 @@ pub fn add_unsupported_data_warnings(
 /// Visitor to collect unsupported datasets
 #[derive(Debug)]
 pub struct CollectUnsupportedDatasetsWarningsVisitor<'a> {
-    pub extract_inline_data: bool,
+    pub planner_config: &'a PlannerConfig,
+    pub task_scope: &'a TaskScope,
     pub warnings: &'a mut Vec<PlannerWarnings>,
 }
 
 impl<'a> CollectUnsupportedDatasetsWarningsVisitor<'a> {
-    pub fn new(extract_inline_data: bool, warnings: &'a mut Vec<PlannerWarnings>) -> Self {
+    pub fn new(
+        planner_config: &'a PlannerConfig,
+        task_scope: &'a TaskScope,
+        warnings: &'a mut Vec<PlannerWarnings>,
+    ) -> Self {
         Self {
-            extract_inline_data,
+            planner_config,
+            task_scope,
             warnings,
         }
     }
@@ -40,7 +47,7 @@ impl<'a> CollectUnsupportedDatasetsWarningsVisitor<'a> {
 
 impl<'a> ChartVisitor for CollectUnsupportedDatasetsWarningsVisitor<'a> {
     fn visit_data(&mut self, data: &DataSpec, scope: &[u32]) -> Result<()> {
-        let data_suported = data.supported(self.extract_inline_data);
+        let data_suported = data.supported(self.planner_config, self.task_scope, scope);
         if !matches!(data_suported, DependencyNodeSupported::Supported) {
             let message = if scope.is_empty() {
                 format!(

--- a/vegafusion-core/src/spec/transform/aggregate.rs
+++ b/vegafusion-core/src/spec/transform/aggregate.rs
@@ -165,4 +165,22 @@ impl TransformSpecTrait for AggregateTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns that are used as grouping fields
+        self.groupby
+            .iter()
+            .filter_map(|groupby_field| {
+                let groupby_field_name = groupby_field.field();
+                if input_local_datetime_columns.contains(&groupby_field_name) {
+                    Some(groupby_field_name)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    }
 }

--- a/vegafusion-core/src/spec/transform/bin.rs
+++ b/vegafusion-core/src/spec/transform/bin.rs
@@ -151,4 +151,13 @@ impl TransformSpecTrait for BinTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as bin passes through all input columns and will
+        // never create a local datetime column.
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/collect.rs
+++ b/vegafusion-core/src/spec/transform/collect.rs
@@ -43,4 +43,13 @@ impl TransformSpecTrait for CollectTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as collect passes through all input columns
+        // and doesn't create an columns
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/extent.rs
+++ b/vegafusion-core/src/spec/transform/extent.rs
@@ -48,4 +48,13 @@ impl TransformSpecTrait for ExtentTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as extent passes through all input columns
+        // and doesn't create an columns
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/filter.rs
+++ b/vegafusion-core/src/spec/transform/filter.rs
@@ -63,4 +63,13 @@ impl TransformSpecTrait for FilterTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as filter passes through all input columns
+        // and doesn't create an columns
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/formula.rs
+++ b/vegafusion-core/src/spec/transform/formula.rs
@@ -65,4 +65,21 @@ impl TransformSpecTrait for FormulaTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as formula passes through all input columns
+        let mut output_local_datetime_columns = Vec::from(input_local_datetime_columns);
+
+        // Try to determine whether formula expression will generate a local datetime column.
+        // We don't have full type info so this isn't exact, but we can capture the most common
+        // local datetime expressions.
+        if self.expr.starts_with("toDate") || self.expr.starts_with("datetime") {
+            output_local_datetime_columns.push(self.as_.clone());
+        }
+
+        output_local_datetime_columns
+    }
 }

--- a/vegafusion-core/src/spec/transform/identifier.rs
+++ b/vegafusion-core/src/spec/transform/identifier.rs
@@ -39,4 +39,13 @@ impl TransformSpecTrait for IdentifierTransformSpec {
         let produced = ColumnUsage::from(self.as_.as_str());
         TransformColumns::PassThrough { usage, produced }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as identifier passes through all input columns
+        // and doesn't create an columns
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -87,4 +87,13 @@ impl TransformSpecTrait for ImputeTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as impute passes through all input columns
+        // and doesn't create an columns
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/joinaggregate.rs
+++ b/vegafusion-core/src/spec/transform/joinaggregate.rs
@@ -104,4 +104,13 @@ impl TransformSpecTrait for JoinAggregateTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as joinaggregate passes through all input columns,
+        // and the new columns created by joinaggregate will never be local datetimes
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/lookup.rs
+++ b/vegafusion-core/src/spec/transform/lookup.rs
@@ -66,4 +66,13 @@ impl TransformSpecTrait for LookupTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as lookup passes through all input columns,
+        // Note: lookup may introduce additional datetime columns that we're not capturing here
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/mod.rs
+++ b/vegafusion-core/src/spec/transform/mod.rs
@@ -193,6 +193,13 @@ pub trait TransformSpecTrait {
     ) -> TransformColumns {
         TransformColumns::Unknown
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        _input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 pub enum TransformColumns {

--- a/vegafusion-core/src/spec/transform/pivot.rs
+++ b/vegafusion-core/src/spec/transform/pivot.rs
@@ -49,4 +49,23 @@ impl TransformSpecTrait for PivotTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns that are used as grouping fields
+        self.groupby
+            .clone()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|groupby_field| {
+                if input_local_datetime_columns.contains(&groupby_field) {
+                    Some(groupby_field.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    }
 }

--- a/vegafusion-core/src/spec/transform/pivot.rs
+++ b/vegafusion-core/src/spec/transform/pivot.rs
@@ -60,7 +60,7 @@ impl TransformSpecTrait for PivotTransformSpec {
             .unwrap_or_default()
             .iter()
             .filter_map(|groupby_field| {
-                if input_local_datetime_columns.contains(&groupby_field) {
+                if input_local_datetime_columns.contains(groupby_field) {
                     Some(groupby_field.clone())
                 } else {
                     None

--- a/vegafusion-core/src/spec/transform/project.rs
+++ b/vegafusion-core/src/spec/transform/project.rs
@@ -54,4 +54,21 @@ impl TransformSpecTrait for ProjectTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns that are used as projection fields
+        self.fields
+            .iter()
+            .filter_map(|project_field| {
+                if input_local_datetime_columns.contains(&project_field) {
+                    Some(project_field.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    }
 }

--- a/vegafusion-core/src/spec/transform/project.rs
+++ b/vegafusion-core/src/spec/transform/project.rs
@@ -63,7 +63,7 @@ impl TransformSpecTrait for ProjectTransformSpec {
         self.fields
             .iter()
             .filter_map(|project_field| {
-                if input_local_datetime_columns.contains(&project_field) {
+                if input_local_datetime_columns.contains(project_field) {
                     Some(project_field.clone())
                 } else {
                     None

--- a/vegafusion-core/src/spec/transform/sequence.rs
+++ b/vegafusion-core/src/spec/transform/sequence.rs
@@ -16,7 +16,7 @@ use crate::error::Result;
 use crate::spec::values::NumberOrSignalSpec;
 use crate::task_graph::task::InputVariable;
 
-/// Struct that serializes to Vega spec for the lookup transform.
+/// Struct that serializes to Vega spec for the sequence transform.
 /// This is currently only needed to report the proper input dependencies
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SequenceTransformSpec {

--- a/vegafusion-core/src/spec/transform/stack.rs
+++ b/vegafusion-core/src/spec/transform/stack.rs
@@ -88,4 +88,13 @@ impl TransformSpecTrait for StackTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as stack passes through all input columns and will
+        // never create a local datetime column.
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-core/src/spec/transform/window.rs
+++ b/vegafusion-core/src/spec/transform/window.rs
@@ -175,4 +175,13 @@ impl TransformSpecTrait for WindowTransformSpec {
             TransformColumns::Unknown
         }
     }
+
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
+        // Keep input local datetime columns as window passes through all input columns
+        // and doesn't create any local datetime columns
+        Vec::from(input_local_datetime_columns)
+    }
 }

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_format.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_format.rs
@@ -89,9 +89,7 @@ fn to_timestamptz_expr(arg: &Expr, schema: &DFSchema, default_input_tz: &str) ->
             fun: Arc::new((*STR_TO_TIMESTAMPTZ_UDF).clone()),
             args: vec![arg.clone(), lit(default_input_tz)],
         },
-        DataType::Null => {
-            arg.clone()
-        }
+        DataType::Null => arg.clone(),
         dtype if is_numeric_datatype(&dtype) => Expr::ScalarUDF {
             fun: Arc::new((*EPOCH_MS_TO_TIMESTAMPTZ_UDF).clone()),
             args: vec![
@@ -156,7 +154,7 @@ pub fn make_time_format_udf() -> ScalarUDF {
         };
 
         if matches!(data_array.data_type(), DataType::Null) {
-            return Ok(ColumnarValue::Array(data_array))
+            return Ok(ColumnarValue::Array(data_array));
         }
 
         let data_array = to_timestamp_ms(&data_array)?;

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_format.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/date_format.rs
@@ -89,6 +89,9 @@ fn to_timestamptz_expr(arg: &Expr, schema: &DFSchema, default_input_tz: &str) ->
             fun: Arc::new((*STR_TO_TIMESTAMPTZ_UDF).clone()),
             args: vec![arg.clone(), lit(default_input_tz)],
         },
+        DataType::Null => {
+            arg.clone()
+        }
         dtype if is_numeric_datatype(&dtype) => Expr::ScalarUDF {
             fun: Arc::new((*EPOCH_MS_TO_TIMESTAMPTZ_UDF).clone()),
             args: vec![
@@ -151,6 +154,10 @@ pub fn make_time_format_udf() -> ScalarUDF {
                 "Expected output_tz to be a scalar".to_string(),
             ));
         };
+
+        if matches!(data_array.data_type(), DataType::Null) {
+            return Ok(ColumnarValue::Array(data_array))
+        }
 
         let data_array = to_timestamp_ms(&data_array)?;
 

--- a/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/datetime.rs
+++ b/vegafusion-rt-datafusion/src/expression/compiler/builtin_functions/date_time/datetime.rs
@@ -196,12 +196,6 @@ pub fn make_datetime_components_udf() -> ScalarUDF {
             let hours = args[3].as_any().downcast_ref::<Int64Array>().unwrap();
             let minutes = args[4].as_any().downcast_ref::<Int64Array>().unwrap();
             let seconds = args[5].as_any().downcast_ref::<Int64Array>().unwrap();
-            println!(
-                "args[6].data_type(): {}, {:?}, {:?}",
-                args[6].data_type(),
-                args[6],
-                args[6].as_any().downcast_ref::<Int64Array>()
-            );
             let millis = args[6].as_any().downcast_ref::<Int64Array>().unwrap();
 
             let num_rows = years.len();

--- a/vegafusion-rt-datafusion/src/task_graph/runtime.rs
+++ b/vegafusion-rt-datafusion/src/task_graph/runtime.rs
@@ -233,6 +233,7 @@ impl TaskGraphRuntime {
             &PlannerConfig {
                 stringify_local_datetimes: true,
                 extract_inline_data: true,
+                allow_client_to_server_comms: false,
                 ..Default::default()
             },
         )?;

--- a/vegafusion-rt-datafusion/src/task_graph/runtime.rs
+++ b/vegafusion-rt-datafusion/src/task_graph/runtime.rs
@@ -509,7 +509,7 @@ impl TaskGraphRuntime {
         let plan = SpecPlan::try_new(
             &spec,
             &PlannerConfig {
-                stringify_local_datetimes: true,
+                stringify_local_datetimes: false,
                 extract_inline_data: true,
                 split_domain_data: false,
                 projection_pushdown: false,

--- a/vegafusion-rt-datafusion/src/task_graph/runtime.rs
+++ b/vegafusion-rt-datafusion/src/task_graph/runtime.rs
@@ -513,6 +513,7 @@ impl TaskGraphRuntime {
                 extract_inline_data: true,
                 split_domain_data: false,
                 projection_pushdown: false,
+                allow_client_to_server_comms: true,
                 ..Default::default()
             },
         )?;

--- a/vegafusion-rt-datafusion/tests/specs/pre_transform/interactive_average.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/pre_transform/interactive_average.vg.json
@@ -1,0 +1,424 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {"name": "brush_store"},
+    {
+      "name": "source_0",
+      "url": "data/seattle-weather.csv",
+      "format": {"type": "csv", "parse": {"date": "date"}, "delimiter": ","},
+      "transform": [
+        {
+          "field": "date",
+          "type": "timeunit",
+          "units": ["month"],
+          "as": ["month_date", "month_date_end"]
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "!length(data(\"brush_store\")) || vlSelectionTest(\"brush_store\", datum)"
+        },
+        {
+          "type": "aggregate",
+          "groupby": [],
+          "ops": ["mean"],
+          "fields": ["precipitation"],
+          "as": ["mean_precipitation"]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"mean_precipitation\"]) && isFinite(+datum[\"mean_precipitation\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["month_date"],
+          "ops": ["mean"],
+          "fields": ["precipitation"],
+          "as": ["mean_precipitation"]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"mean_precipitation\"]) && isFinite(+datum[\"mean_precipitation\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 20},
+    {
+      "name": "width",
+      "update": "bandspace(domain('x').length, 0.1, 0.05) * x_step"
+    },
+    {
+      "name": "unit",
+      "value": {},
+      "on": [
+        {"events": "mousemove", "update": "isTuple(group()) ? group() : unit"}
+      ]
+    },
+    {
+      "name": "brush",
+      "update": "vlSelectionResolve(\"brush_store\", \"union\")"
+    },
+    {
+      "name": "brush_x",
+      "value": [],
+      "on": [
+        {
+          "events": {
+            "source": "scope",
+            "type": "mousedown",
+            "filter": [
+              "!event.item || event.item.mark.name !== \"brush_brush\""
+            ]
+          },
+          "update": "[x(unit), x(unit)]"
+        },
+        {
+          "events": {
+            "source": "window",
+            "type": "mousemove",
+            "consume": true,
+            "between": [
+              {
+                "source": "scope",
+                "type": "mousedown",
+                "filter": [
+                  "!event.item || event.item.mark.name !== \"brush_brush\""
+                ]
+              },
+              {"source": "window", "type": "mouseup"}
+            ]
+          },
+          "update": "[brush_x[0], clamp(x(unit), 0, width)]"
+        },
+        {"events": {"signal": "brush_scale_trigger"}, "update": "[0, 0]"},
+        {
+          "events": [{"source": "view", "type": "dblclick"}],
+          "update": "[0, 0]"
+        },
+        {
+          "events": {"signal": "brush_translate_delta"},
+          "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, width)"
+        },
+        {
+          "events": {"signal": "brush_zoom_delta"},
+          "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, width)"
+        }
+      ]
+    },
+    {
+      "name": "brush_month_date",
+      "on": [
+        {
+          "events": {"signal": "brush_x"},
+          "update": "brush_x[0] === brush_x[1] ? null : invert(\"x\", brush_x)"
+        }
+      ]
+    },
+    {
+      "name": "brush_scale_trigger",
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}],
+          "update": "(!isArray(brush_month_date) || (invert(\"x\", brush_x)[0] === brush_month_date[0] && invert(\"x\", brush_x)[1] === brush_month_date[1])) ? brush_scale_trigger : {}"
+        }
+      ]
+    },
+    {
+      "name": "brush_tuple",
+      "on": [
+        {
+          "events": [{"signal": "brush_month_date"}],
+          "update": "brush_month_date ? {unit: \"layer_0\", fields: brush_tuple_fields, values: [brush_month_date]} : null"
+        }
+      ]
+    },
+    {
+      "name": "brush_tuple_fields",
+      "value": [{"field": "month_date", "channel": "x", "type": "E"}]
+    },
+    {
+      "name": "brush_translate_anchor",
+      "value": {},
+      "on": [
+        {
+          "events": [
+            {"source": "scope", "type": "mousedown", "markname": "brush_brush"}
+          ],
+          "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
+        }
+      ]
+    },
+    {
+      "name": "brush_translate_delta",
+      "value": {},
+      "on": [
+        {
+          "events": [
+            {
+              "source": "window",
+              "type": "mousemove",
+              "consume": true,
+              "between": [
+                {
+                  "source": "scope",
+                  "type": "mousedown",
+                  "markname": "brush_brush"
+                },
+                {"source": "window", "type": "mouseup"}
+              ]
+            }
+          ],
+          "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+        }
+      ]
+    },
+    {
+      "name": "brush_zoom_anchor",
+      "on": [
+        {
+          "events": [
+            {
+              "source": "scope",
+              "type": "wheel",
+              "consume": true,
+              "markname": "brush_brush"
+            }
+          ],
+          "update": "{x: x(unit), y: y(unit)}"
+        }
+      ]
+    },
+    {
+      "name": "brush_zoom_delta",
+      "on": [
+        {
+          "events": [
+            {
+              "source": "scope",
+              "type": "wheel",
+              "consume": true,
+              "markname": "brush_brush"
+            }
+          ],
+          "force": true,
+          "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+        }
+      ]
+    },
+    {
+      "name": "brush_modify",
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "brush_brush_bg",
+      "type": "rect",
+      "clip": true,
+      "encode": {
+        "enter": {"fill": {"value": "#333"}, "fillOpacity": {"value": 0.125}},
+        "update": {
+          "x": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "signal": "brush_x[0]"
+            },
+            {"value": 0}
+          ],
+          "y": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "value": 0
+            },
+            {"value": 0}
+          ],
+          "x2": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "signal": "brush_x[1]"
+            },
+            {"value": 0}
+          ],
+          "y2": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "field": {"group": "height"}
+            },
+            {"value": 0}
+          ]
+        }
+      }
+    },
+    {
+      "name": "layer_0_marks",
+      "type": "rect",
+      "style": ["bar"],
+      "interactive": true,
+      "from": {"data": "data_1"},
+      "encode": {
+        "update": {
+          "fill": {"value": "#4c78a8"},
+          "opacity": [
+            {
+              "test": "!length(data(\"brush_store\")) || vlSelectionTest(\"brush_store\", datum)",
+              "value": 1
+            },
+            {"value": 0.7}
+          ],
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"date (month): \" + (timeFormat(datum[\"month_date\"], timeUnitSpecifier([\"month\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; Mean of precipitation: \" + (format(datum[\"mean_precipitation\"], \"\"))"
+          },
+          "x": {"scale": "x", "field": "month_date"},
+          "width": {"signal": "max(0.25, bandwidth('x'))"},
+          "y": {"scale": "y", "field": "mean_precipitation"},
+          "y2": {"scale": "y", "value": 0}
+        }
+      }
+    },
+    {
+      "name": "layer_1_marks",
+      "type": "rule",
+      "style": ["rule"],
+      "interactive": false,
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "stroke": {"value": "firebrick"},
+          "description": {
+            "signal": "\"Mean of precipitation: \" + (format(datum[\"mean_precipitation\"], \"\"))"
+          },
+          "x": {"field": {"group": "width"}},
+          "x2": {"value": 0},
+          "y": {"scale": "y", "field": "mean_precipitation"},
+          "strokeWidth": {"value": 3}
+        }
+      }
+    },
+    {
+      "name": "brush_brush",
+      "type": "rect",
+      "clip": true,
+      "encode": {
+        "enter": {"fill": {"value": "transparent"}},
+        "update": {
+          "x": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "signal": "brush_x[0]"
+            },
+            {"value": 0}
+          ],
+          "y": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "value": 0
+            },
+            {"value": 0}
+          ],
+          "x2": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "signal": "brush_x[1]"
+            },
+            {"value": 0}
+          ],
+          "y2": [
+            {
+              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0\"",
+              "field": {"group": "height"}
+            },
+            {"value": 0}
+          ],
+          "stroke": [
+            {"test": "brush_x[0] !== brush_x[1]", "value": "white"},
+            {"value": null}
+          ]
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {"data": "data_1", "field": "month_date", "sort": true},
+      "range": {"step": {"signal": "x_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "fields": [
+          {"data": "data_1", "field": "mean_precipitation"},
+          {"data": "data_0", "field": "mean_precipitation"}
+        ]
+      },
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "y",
+      "orient": "left",
+      "gridScale": "x",
+      "grid": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "date (month)",
+      "format": {
+        "signal": "timeUnitSpecifier([\"month\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"})"
+      },
+      "formatType": "time",
+      "labelOverlap": true,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "Mean of precipitation",
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates the `pre_transform_spec` logic to avoid breaking interactivity in the output chart specs.

Previously, `pre_transform_spec` the same planning approach as `VegaFusionWidget`. This approach extracts all supported data transforms into the server specification and then computes which datasets and signals must be transferred to and from the client to maintain interactivity.  This is what we want for `VegaFusionWidget`, but not for `pre_transform_spec`.

The output of `pre_transform_spec` is designed to be rendered by a regular (non-VegaFusion aware) Vega renderer, so there is no way to perform client-to-server communications.  Instead, what we want is for the planner to extract as much as possible for evaluation on the server without introducing any client-to-server communication requirements.  That's what this PR accomplishes.

Along the way, some improvements to local datetime stringification were required as well.