### PR TITLE
Update the pre_transform_* API to input and return JSON objects instead of strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pythonize"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f7f0c136f5fbc01868185eef462800e49659eb23acca83b9e884367a006acb6"
+dependencies = [
+ "pyo3",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,6 +3961,7 @@ dependencies = [
  "env_logger",
  "log",
  "pyo3",
+ "pythonize",
  "serde",
  "serde_json",
  "tokio",

--- a/python/vegafusion/tests/test_input_utc.py
+++ b/python/vegafusion/tests/test_input_utc.py
@@ -7,10 +7,9 @@ def test_input_utc():
     (pre_transformed, warnings) = vf.runtime.pre_transform_spec(
         input_spec(), "UTC", "UTC", inline_datasets={"seattle_weather": load_dataset()}
     )
-    pre_transformed_json = json.loads(pre_transformed)
-    print(json.dumps(pre_transformed_json, indent=2))
-    expected_json = json.loads(expected_spec())
-    assert pre_transformed_json == expected_json
+    print(json.dumps(pre_transformed, indent=2))
+    expected = expected_spec()
+    assert pre_transformed == expected
 
 
 def load_dataset():
@@ -160,7 +159,7 @@ def input_spec():
 """
 
 def expected_spec():
-    return r"""
+    return json.loads(r"""
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "data": [
@@ -762,4 +761,4 @@ def expected_spec():
   "padding": 5,
   "background": "white"
 }
-    """
+    """)

--- a/python/vegafusion/tests/test_pretransform.py
+++ b/python/vegafusion/tests/test_pretransform.py
@@ -5,7 +5,7 @@ import json
 from datetime import date
 
 def order_items_spec():
-    return r"""
+    return json.loads(r"""
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "background": "white",
@@ -76,11 +76,11 @@ def order_items_spec():
     }
   ]
 }
-"""
+""")
 
 
 def movies_histogram_spec(agg="count"):
-    return """
+    return json.loads("""
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "background": "white",
@@ -207,11 +207,11 @@ def movies_histogram_spec(agg="count"):
       "zindex": 0
     }
   ]
-}"""
+}""")
 
 
 def standalone_aggregate_spec(agg="count"):
-    return """
+    return json.loads("""
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "data": [
@@ -489,11 +489,11 @@ def standalone_aggregate_spec(agg="count"):
     "warnings": []
   }
 }    
-    """
+    """)
 
 
 def date_column_spec():
-    return r"""
+    return json.loads(r"""
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "description": "A scatterplot showing horsepower and miles per gallons for various cars.",
@@ -545,11 +545,11 @@ def date_column_spec():
     }
   ]
 }
-"""
+""")
 
 
 def period_in_col_name_spec():
-    return r"""
+    return json.loads(r"""
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "background": "white",
@@ -667,11 +667,11 @@ def period_in_col_name_spec():
     }
   ]
 } 
-    """
+    """)
 
 
 def nat_bar_spec():
-    return r"""
+    return json.loads(r"""
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "background": "white",
@@ -796,7 +796,7 @@ def nat_bar_spec():
     "axis": {"domain": false}
   }
 }
-    """
+    """)
 
 
 def test_pre_transform_multi_partition():
@@ -809,7 +809,7 @@ def test_pre_transform_multi_partition():
     new_spec, warnings = vf.runtime.pre_transform_spec(vega_spec, "UTC", inline_datasets={
         "order_items": order_items,
     })
-    new_spec = json.loads(new_spec)
+
     assert new_spec["data"][1] == dict(
         name="data_0",
         values=[
@@ -830,7 +830,7 @@ def test_pre_transform_cache_cleared():
         new_spec, warnings = vf.runtime.pre_transform_spec(vega_spec, "UTC", inline_datasets={
             "order_items": order_items,
         })
-        new_spec = json.loads(new_spec)
+
         assert new_spec["data"][1] == dict(
             name="data_0",
             values=[

--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -80,7 +80,7 @@ class VegaFusionRuntime:
         Evaluate supported transforms in an input Vega specification and produce a new
         specification with pre-transformed datasets included inline.
 
-        :param spec: A Vega specification
+        :param spec: A Vega specification dict or JSON string
         :param local_tz: Name of timezone to be considered local. E.g. 'America/New_York'.
             This can be computed for the local system using the tzlocal package and the
             tzlocal.get_localzone_name() function.
@@ -117,7 +117,6 @@ class VegaFusionRuntime:
                 row_limit=row_limit,
                 inline_datasets=inline_dataset_bytes
             )
-            warnings = json.loads(warnings)
             return new_spec, warnings
 
     def pre_transform_datasets(self, spec, datasets, local_tz, default_input_tz=None, inline_datasets=None):
@@ -125,7 +124,7 @@ class VegaFusionRuntime:
         Extract the fully evaluated form of the requested datasets from a Vega specification
         as pandas DataFrames.
 
-        :param spec: A Vega specification
+        :param spec: A Vega specification dict or JSON string
         :param datasets: A list with elements that are either:
           - The name of a top-level dataset as a string
           - A two-element tuple where the first element is the name of a dataset as a string
@@ -176,7 +175,6 @@ class VegaFusionRuntime:
             # Deserialize values to Arrow tables
             datasets = [pa.ipc.deserialize_pandas(value) for value in values]
 
-            warnings = json.loads(warnings)
             return datasets, warnings
 
     @property

--- a/vegafusion-python-embed/Cargo.toml
+++ b/vegafusion-python-embed/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = [ "cdylib",]
 [dependencies]
 log = "0.4.17"
 env_logger = "0.9.0"
+pythonize = "0.17.0"
 
 [dependencies.deterministic-hash]
 version = "1.0.1"

--- a/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
+++ b/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
@@ -2,7 +2,6 @@
 mod tests {
     use crate::crate_dir;
     use std::fs;
-    use vegafusion_core::proto::gen::services::pre_transform_spec_result;
     use vegafusion_core::spec::chart::ChartSpec;
     use vegafusion_core::spec::transform::TransformSpec;
     use vegafusion_rt_datafusion::task_graph::runtime::TaskGraphRuntime;
@@ -20,7 +19,7 @@ mod tests {
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
-        let (chart_spec, warnings) = runtime
+        let (chart_spec, _warnings) = runtime
             .pre_transform_spec(&spec, "UTC", &None, None, Default::default())
             .await
             .unwrap();

--- a/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
+++ b/vegafusion-rt-datafusion/tests/test_destringify_selection_datasets.rs
@@ -15,43 +15,35 @@ mod tests {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
-        let result = runtime
-            .pre_transform_spec(&spec_str, "UTC", &None, None, Default::default())
+        let (chart_spec, warnings) = runtime
+            .pre_transform_spec(&spec, "UTC", &None, None, Default::default())
             .await
             .unwrap();
 
-        match result.result.unwrap() {
-            pre_transform_spec_result::Result::Response(response) => {
-                let chart_spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
+        let click_store = &chart_spec.data[2];
+        assert_eq!(click_store.name.as_str(), "click_store");
+        assert_eq!(click_store.transform.len(), 1);
+        if let TransformSpec::Formula(formula) = &click_store.transform[0] {
+            assert_eq!(formula.expr, "[toDate(datum.values[0]), datum.values[1]]");
+        } else {
+            panic!("Unexpected transform")
+        }
 
-                let click_store = &chart_spec.data[2];
-                assert_eq!(click_store.name.as_str(), "click_store");
-                assert_eq!(click_store.transform.len(), 1);
-                if let TransformSpec::Formula(formula) = &click_store.transform[0] {
-                    assert_eq!(formula.expr, "[toDate(datum.values[0]), datum.values[1]]");
-                } else {
-                    panic!("Unexpected transform")
-                }
-
-                let drag_store = &chart_spec.data[3];
-                assert_eq!(drag_store.name.as_str(), "drag_store");
-                assert_eq!(drag_store.transform.len(), 1);
-                if let TransformSpec::Formula(formula) = &drag_store.transform[0] {
-                    assert_eq!(
-                        formula.expr,
-                        "[[toDate(datum.values[0][0]), toDate(datum.values[0][1])]]"
-                    );
-                } else {
-                    panic!("Unexpected transform")
-                }
-            }
-            pre_transform_spec_result::Result::Error(err) => {
-                panic!("Unexpected pre_transform_spec error: {:?}", err);
-            }
+        let drag_store = &chart_spec.data[3];
+        assert_eq!(drag_store.name.as_str(), "drag_store");
+        assert_eq!(drag_store.transform.len(), 1);
+        if let TransformSpec::Formula(formula) = &drag_store.transform[0] {
+            assert_eq!(
+                formula.expr,
+                "[[toDate(datum.values[0][0]), toDate(datum.values[0][1])]]"
+            );
+        } else {
+            panic!("Unexpected transform")
         }
     }
 }

--- a/vegafusion-rt-datafusion/tests/test_pre_transform_values.rs
+++ b/vegafusion-rt-datafusion/tests/test_pre_transform_values.rs
@@ -15,6 +15,7 @@ mod tests {
     use vegafusion_core::data::table::VegaFusionTable;
     use vegafusion_core::error::VegaFusionError;
     use vegafusion_core::proto::gen::tasks::Variable;
+    use vegafusion_core::spec::chart::ChartSpec;
     use vegafusion_rt_datafusion::data::dataset::VegaFusionDataset;
     use vegafusion_rt_datafusion::data::table::VegaFusionTableUtils;
     use vegafusion_rt_datafusion::task_graph::runtime::TaskGraphRuntime;
@@ -24,13 +25,14 @@ mod tests {
         // Load spec
         let spec_path = format!("{}/tests/specs/vegalite/histogram.vg.json", crate_dir());
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
         let (values, warnings) = runtime
             .pre_transform_values(
-                &spec_str,
+                &spec,
                 &[(Variable::new_data("source_0"), vec![])],
                 "UTC",
                 &None,
@@ -69,6 +71,7 @@ mod tests {
         // Load spec
         let spec_path = format!("{}/tests/specs/vegalite/area_density.vg.json", crate_dir());
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
@@ -76,7 +79,7 @@ mod tests {
         // Check existent but unsupported dataset name
         let result = runtime
             .pre_transform_values(
-                &spec_str,
+                &spec,
                 &[(Variable::new_data("source_0"), vec![])],
                 "UTC",
                 &None,
@@ -97,7 +100,7 @@ mod tests {
         // Check non-existent dataset name
         let result = runtime
             .pre_transform_values(
-                &spec_str,
+                &spec,
                 &[(Variable::new_data("bogus_0"), vec![])],
                 "UTC",
                 &None,
@@ -120,6 +123,7 @@ mod tests {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
@@ -138,7 +142,7 @@ mod tests {
 
         let (values, warnings) = runtime
             .pre_transform_values(
-                &spec_str,
+                &spec,
                 &[(Variable::new_data("source_0"), vec![])],
                 "UTC",
                 &None,
@@ -174,13 +178,14 @@ mod tests {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
         let (values, warnings) = runtime
             .pre_transform_values(
-                &spec_str,
+                &spec,
                 &[(Variable::new_data("data_3"), vec![])],
                 "UTC",
                 &None,
@@ -217,13 +222,14 @@ mod tests {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
         let (values, warnings) = runtime
             .pre_transform_values(
-                &spec_str,
+                &spec,
                 &[
                     (Variable::new_data("click_selected"), vec![]),
                     (Variable::new_data("drag_selected"), vec![]),

--- a/vegafusion-rt-datafusion/tests/test_stringify_datetimes.rs
+++ b/vegafusion-rt-datafusion/tests/test_stringify_datetimes.rs
@@ -15,7 +15,6 @@ mod test_stringify_datetimes {
     use crate::{crate_dir, TOKIO_RUNTIME};
     use rstest::rstest;
     use std::fs;
-    use vegafusion_core::proto::gen::services::pre_transform_spec_result;
     use vegafusion_core::spec::chart::ChartSpec;
     use vegafusion_rt_datafusion::task_graph::runtime::TaskGraphRuntime;
 
@@ -76,14 +75,15 @@ mod test_stringify_datetimes {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
         let local_tz = local_tz.to_string();
 
-        let pre_tx_result = runtime
+        let (spec, _warnings) = runtime
             .pre_transform_spec(
-                &spec_str,
+                &spec,
                 &local_tz,
                 &Some(default_input_tz.to_string()),
                 None,
@@ -92,36 +92,28 @@ mod test_stringify_datetimes {
             .await
             .unwrap();
 
-        match pre_tx_result.result.unwrap() {
-            pre_transform_spec_result::Result::Error(err) => {
-                panic!("pre_transform_spec error: {:?}", err);
-            }
-            pre_transform_spec_result::Result::Response(response) => {
-                let spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
-                let data = spec.data[0].values.as_ref().unwrap();
-                let values = data.as_array().expect("Expected array");
-                let first = values[0].as_object().expect("Expected object");
-                println!("{:?}", first);
+        let data = spec.data[0].values.as_ref().unwrap();
+        let values = data.as_array().expect("Expected array");
+        let first = values[0].as_object().expect("Expected object");
+        println!("{:?}", first);
 
-                // Check hours_time
-                let hours_time = first
-                    .get("hours_time")
-                    .expect("Expected hours_time")
-                    .as_str()
-                    .expect("Expected string")
-                    .to_string();
-                assert_eq!(hours_time, expected_hours_time);
+        // Check hours_time
+        let hours_time = first
+            .get("hours_time")
+            .expect("Expected hours_time")
+            .as_str()
+            .expect("Expected string")
+            .to_string();
+        assert_eq!(hours_time, expected_hours_time);
 
-                // Check hours_time_end
-                let hours_time_end = first
-                    .get("hours_time_end")
-                    .expect("Expected hours_time_end")
-                    .as_str()
-                    .expect("Expected string")
-                    .to_string();
-                assert_eq!(hours_time_end, expected_hours_time_end);
-            }
-        }
+        // Check hours_time_end
+        let hours_time_end = first
+            .get("hours_time_end")
+            .expect("Expected hours_time_end")
+            .as_str()
+            .expect("Expected string")
+            .to_string();
+        assert_eq!(hours_time_end, expected_hours_time_end);
     }
 
     #[tokio::test]
@@ -132,6 +124,7 @@ mod test_stringify_datetimes {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
@@ -139,9 +132,9 @@ mod test_stringify_datetimes {
         let local_tz = "UTC".to_string();
         let default_input_tz = "UTC".to_string();
 
-        let pre_tx_result = runtime
+        let (spec, _warnings) = runtime
             .pre_transform_spec(
-                &spec_str,
+                &spec,
                 &local_tz,
                 &Some(default_input_tz),
                 None,
@@ -150,47 +143,37 @@ mod test_stringify_datetimes {
             .await
             .unwrap();
 
-        let pre_tx_result = pre_tx_result.result.unwrap();
+        println!("{}", serde_json::to_string_pretty(&spec).unwrap());
 
-        match pre_tx_result {
-            pre_transform_spec_result::Result::Response(response) => {
-                let spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
-                println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+        assert_eq!(&spec.data[0].name, "source_0");
+        let data = spec.data[0].values.as_ref().unwrap();
+        let values = data.as_array().expect("Expected array");
+        let first = values[0].as_object().expect("Expected object");
 
-                assert_eq!(&spec.data[0].name, "source_0");
-                let data = spec.data[0].values.as_ref().unwrap();
-                let values = data.as_array().expect("Expected array");
-                let first = values[0].as_object().expect("Expected object");
+        // Check hours_time
+        let expected_month_date = "2012-01-01T00:00:00.000";
+        let hours_time = first
+            .get("month_date")
+            .expect("Expected month_date")
+            .as_str()
+            .expect("Expected month_date value to be a string")
+            .to_string();
+        assert_eq!(hours_time, expected_month_date);
 
-                // Check hours_time
-                let expected_month_date = "2012-01-01T00:00:00.000";
-                let hours_time = first
-                    .get("month_date")
-                    .expect("Expected month_date")
-                    .as_str()
-                    .expect("Expected month_date value to be a string")
-                    .to_string();
-                assert_eq!(hours_time, expected_month_date);
+        // Check domain includes string datetimes
+        assert_eq!(&spec.data[1].name, "source_0_x_domain_month_date");
+        let data = spec.data[1].values.as_ref().unwrap();
+        let values = data.as_array().expect("Expected array");
+        let first = values[0].as_object().expect("Expected object");
 
-                // Check domain includes string datetimes
-                assert_eq!(&spec.data[1].name, "source_0_x_domain_month_date");
-                let data = spec.data[1].values.as_ref().unwrap();
-                let values = data.as_array().expect("Expected array");
-                let first = values[0].as_object().expect("Expected object");
-
-                let expected_month_date = "2012-01-01T00:00:00.000";
-                let hours_time = first
-                    .get("month_date")
-                    .expect("Expected month_date")
-                    .as_str()
-                    .expect("Expected month_date value to be a string")
-                    .to_string();
-                assert_eq!(hours_time, expected_month_date);
-            }
-            pre_transform_spec_result::Result::Error(err) => {
-                panic!("Pre Transform Error: {:?}", err)
-            }
-        }
+        let expected_month_date = "2012-01-01T00:00:00.000";
+        let hours_time = first
+            .get("month_date")
+            .expect("Expected month_date")
+            .as_str()
+            .expect("Expected month_date value to be a string")
+            .to_string();
+        assert_eq!(hours_time, expected_month_date);
     }
 
     #[rstest(
@@ -224,13 +207,13 @@ mod test_stringify_datetimes {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
-
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
-        let pre_tx_result = runtime
+        let (spec, _warnings) = runtime
             .pre_transform_spec(
-                &spec_str,
+                &spec,
                 local_tz,
                 &Some(default_input_tz.to_string()),
                 None,
@@ -239,45 +222,35 @@ mod test_stringify_datetimes {
             .await
             .unwrap();
 
-        let pre_tx_result = pre_tx_result.result.unwrap();
+        println!("{}", serde_json::to_string_pretty(&spec).unwrap());
 
-        match pre_tx_result {
-            pre_transform_spec_result::Result::Response(response) => {
-                let spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
-                println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+        assert_eq!(&spec.data[1].name, "data_0");
+        let data = spec.data[1].values.as_ref().unwrap();
+        let values = data.as_array().expect("Expected array");
+        let first = values[0].as_object().expect("Expected object");
 
-                assert_eq!(&spec.data[1].name, "data_0");
-                let data = spec.data[1].values.as_ref().unwrap();
-                let values = data.as_array().expect("Expected array");
-                let first = values[0].as_object().expect("Expected object");
+        // Check hours_time
+        let hours_time = first
+            .get("ship_date")
+            .expect("Expected ship_date")
+            .as_str()
+            .expect("Expected ship_date value to be a string")
+            .to_string();
+        assert_eq!(hours_time, expected_ship_date);
 
-                // Check hours_time
-                let hours_time = first
-                    .get("ship_date")
-                    .expect("Expected ship_date")
-                    .as_str()
-                    .expect("Expected ship_date value to be a string")
-                    .to_string();
-                assert_eq!(hours_time, expected_ship_date);
+        // Check domain includes string datetimes
+        assert_eq!(&spec.data[3].name, "data_0_color_domain_ship_date");
+        let data = spec.data[3].values.as_ref().unwrap();
+        let values = data.as_array().expect("Expected array");
+        let first = values[0].as_object().expect("Expected object");
 
-                // Check domain includes string datetimes
-                assert_eq!(&spec.data[3].name, "data_0_color_domain_ship_date");
-                let data = spec.data[3].values.as_ref().unwrap();
-                let values = data.as_array().expect("Expected array");
-                let first = values[0].as_object().expect("Expected object");
-
-                let hours_time = first
-                    .get("ship_date")
-                    .expect("Expected ship_date")
-                    .as_str()
-                    .expect("Expected ship_date value to be a string")
-                    .to_string();
-                assert_eq!(hours_time, expected_ship_date);
-            }
-            pre_transform_spec_result::Result::Error(err) => {
-                panic!("Pre Transform Error: {:?}", err)
-            }
-        }
+        let hours_time = first
+            .get("ship_date")
+            .expect("Expected ship_date")
+            .as_str()
+            .expect("Expected ship_date value to be a string")
+            .to_string();
+        assert_eq!(hours_time, expected_ship_date);
     }
 
     /// This test checks that we're able to identify local timestamp column usage inside facet
@@ -294,13 +267,14 @@ mod test_stringify_datetimes {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
-        let pre_tx_result = runtime
+        let (spec, _warnings) = runtime
             .pre_transform_spec(
-                &spec_str,
+                &spec,
                 local_tz,
                 &Some(default_input_tz.to_string()),
                 None,
@@ -309,32 +283,22 @@ mod test_stringify_datetimes {
             .await
             .unwrap();
 
-        let pre_tx_result = pre_tx_result.result.unwrap();
+        println!("{}", serde_json::to_string_pretty(&spec).unwrap());
 
-        match pre_tx_result {
-            pre_transform_spec_result::Result::Response(response) => {
-                let spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
-                println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+        assert_eq!(&spec.data[7].name, "data_5");
 
-                assert_eq!(&spec.data[7].name, "data_5");
+        let data = spec.data[7].values.as_ref().unwrap();
+        let values = data.as_array().expect("Expected array");
+        let first = values[0].as_object().expect("Expected object");
 
-                let data = spec.data[7].values.as_ref().unwrap();
-                let values = data.as_array().expect("Expected array");
-                let first = values[0].as_object().expect("Expected object");
-
-                // Check year_date
-                let hours_time = first
-                    .get("year_date")
-                    .expect("Expected year_date column")
-                    .as_str()
-                    .expect("Expected year_date value to be a string")
-                    .to_string();
-                assert_eq!(hours_time, expected_year_date);
-            }
-            pre_transform_spec_result::Result::Error(err) => {
-                panic!("Pre Transform Error: {:?}", err)
-            }
-        }
+        // Check year_date
+        let hours_time = first
+            .get("year_date")
+            .expect("Expected year_date column")
+            .as_str()
+            .expect("Expected year_date value to be a string")
+            .to_string();
+        assert_eq!(hours_time, expected_year_date);
     }
 
     #[tokio::test]
@@ -345,40 +309,32 @@ mod test_stringify_datetimes {
             crate_dir()
         );
         let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
         let runtime = TaskGraphRuntime::new(Some(16), Some(1024_i32.pow(3) as usize));
 
-        let pre_tx_result = runtime
-            .pre_transform_spec(&spec_str, "UTC", &None, None, Default::default())
+        let (spec, _warnings) = runtime
+            .pre_transform_spec(&spec, "UTC", &None, None, Default::default())
             .await
             .unwrap();
-        let pre_tx_result = pre_tx_result.result.unwrap();
 
-        match pre_tx_result {
-            pre_transform_spec_result::Result::Response(response) => {
-                let spec: ChartSpec = serde_json::from_str(&response.spec).unwrap();
-                println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+        println!("{}", serde_json::to_string_pretty(&spec).unwrap());
 
-                assert_eq!(&spec.data[1].name, "source_0");
+        assert_eq!(&spec.data[1].name, "source_0");
 
-                let data = spec.data[1].values.as_ref().unwrap();
-                let values = data.as_array().expect("Expected array");
-                let first = values[0].as_object().expect("Expected object");
+        let data = spec.data[1].values.as_ref().unwrap();
+        let values = data.as_array().expect("Expected array");
+        let first = values[0].as_object().expect("Expected object");
 
-                // Check year_date
-                let month_date = first
-                    .get("month_date")
-                    .expect("Expected month_date column")
-                    .as_str()
-                    .expect("Expected month_date value to be a string")
-                    .to_string();
-                assert_eq!(month_date, "2012-01-01T00:00:00.000");
-            }
-            pre_transform_spec_result::Result::Error(err) => {
-                panic!("Pre Transform Error: {:?}", err)
-            }
-        }
+        // Check year_date
+        let month_date = first
+            .get("month_date")
+            .expect("Expected month_date column")
+            .as_str()
+            .expect("Expected month_date value to be a string")
+            .to_string();
+        assert_eq!(month_date, "2012-01-01T00:00:00.000");
     }
 }
 


### PR DESCRIPTION
Small API update to reduce JSON serialization by having the pre_transform_* functions input and return objects rather than strings.

In Rust this means inputting and returning ChartSpec objects instead of strings

In Python this means inputting and returning dicts instead of strings.