### PR TITLE
CI speedups

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -165,7 +165,7 @@ jobs:
           command: build
           manylinux: 2014
           rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.10 -i python3.9 -i python3.8 -i python3.7
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.11 -i python3.10 -i python3.9 -i python3.8 -i python3.7
       - name: Download Apple Silicon toolchain
         if: ${{ matrix.options[1] == 'osx-arm64' }}
         run: |
@@ -177,7 +177,7 @@ jobs:
           maturin-version: 0.12.20
           command: build
           rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin -i python3.10 -i python3.9 -i python3.8 -i python3.7
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin -i python3.11 -i python3.10 -i python3.9 -i python3.8 -i python3.7
       - name: Remove unwanted universal
         if: ${{ runner.os == 'macOS' }}
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -288,8 +288,8 @@ jobs:
             python/vegafusion-jupyter/dist/*.whl
             python/vegafusion-jupyter/dist/*.tar.gz
 
-  test-vegafusion-jupyter:
-    needs: [ build-vegafusion-python-embed, build-vegafusion-jupyter-package ]
+  test-vegafusion-python:
+    needs: [ build-vegafusion-wheel, build-vegafusion-jupyter-package ]
     strategy:
       matrix:
         options: [
@@ -306,6 +306,22 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          maturin-version: 0.12.20
+          command: develop
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml
       - name: Create conda test environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -325,11 +341,6 @@ jobs:
         with:
           name: vegafusion-wheel
           path: target/wheels/
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@v2
-        with:
-          name: vegafusion-jupyter-packages
-          path: target/wheels/
       - name: Download vegafusion-jupyter wheel
         uses: actions/download-artifact@v2
         with:
@@ -338,7 +349,6 @@ jobs:
       - name: install wheels
         working-directory: target/wheels/
         run: |
-          python -m pip install vegafusion_python*${{ matrix.options[4] }}*${{ matrix.options[3] }}*.whl
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_jupyter*.whl
           python -m pip install vl-convert-python

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -133,20 +133,21 @@ jobs:
             vegafusion-server-*
 
   build-vegafusion-python-embed:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.options[0] }}
     strategy:
       matrix:
-        os:
-         - ubuntu-latest
-         - windows-2022
-         - macos-11
+        options:
+         - [ubuntu-latest, linux-64]
+         - [windows-2022, win-64]
+         - [macos-11, osx-64]
+         - [macos-11, osx-arm64]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Install protoc on Window
+        if: ${{ runner.os == 'Windows' }}
         run: |
           choco install --yes protoc
-        if: ${{ runner.os == 'Windows' }}
       - name: Install latest stable Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -157,6 +158,7 @@ jobs:
         with:
           cache-on-failure: True
       - name: Build wheels
+        if: ${{ matrix.options[1] != 'osx-arm64' }}
         uses: messense/maturin-action@v1
         with:
           maturin-version: 0.12.20
@@ -165,11 +167,11 @@ jobs:
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml --strip -i python3.10 -i python3.9 -i python3.8 -i python3.7
       - name: Download Apple Silicon toolchain
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ matrix.options[1] == 'osx-arm64' }}
         run: |
           rustup target add aarch64-apple-darwin
       - name: Build Apple Silicon wheels
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ matrix.options[1] == 'osx-arm64' }}
         uses: messense/maturin-action@v1
         with:
           maturin-version: 0.12.20

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -342,7 +342,7 @@ jobs:
       - name: Download vegafusion-jupyter wheel
         uses: actions/download-artifact@v2
         with:
-          name: vegafusion-python-embed-wheels
+          name: vegafusion-jupyter-packages
           path: target/wheels/
       - name: install wheels
         working-directory: target/wheels/

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -324,7 +324,7 @@ jobs:
           cache-on-failure: True
       - name: Build vegafusion-python-embed in development mode
         run: |
-          maturin develop --release
+          maturin develop --release -m vegafusion-python-embed/Cargo.toml
       - name: Install Chrome
         uses: browser-actions/setup-chrome@latest
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -306,6 +306,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+      - name: Create conda test environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: vegafusion_dev
+          miniforge-version: latest
+          environment-file: python/vegafusion-jupyter/conda-${{ matrix.options[1] }}-${{ matrix.options[4] }}.lock
       - name: Install latest stable Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -322,13 +329,6 @@ jobs:
           command: develop
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml
-      - name: Create conda test environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          activate-environment: vegafusion_dev
-          miniforge-version: latest
-          environment-file: python/vegafusion-jupyter/conda-${{ matrix.options[1] }}-${{ matrix.options[4] }}.lock
       - name: Install Chrome
         uses: browser-actions/setup-chrome@latest
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -192,6 +192,7 @@ jobs:
             target/wheels/*cp38*.whl
             target/wheels/*cp39*.whl
             target/wheels/*cp310*.whl
+            target/wheels/*cp311*.whl
 
   build-vegafusion-wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -322,13 +322,9 @@ jobs:
         uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: True
-      - name: Build wheels
-        uses: messense/maturin-action@v1
-        with:
-          maturin-version: 0.12.20
-          command: develop
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml
+      - name: Build vegafusion-python-embed in development mode
+        run: |
+          maturin develop --release
       - name: Install Chrome
         uses: browser-actions/setup-chrome@latest
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -347,6 +347,7 @@ jobs:
       - name: install wheels
         working-directory: target/wheels/
         run: |
+          ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_jupyter*.whl
           python -m pip install vl-convert-python


### PR DESCRIPTION
Run python tests on the development build of vegafusion-python-embed. This way the Python tests don't need to wait for all of the vegafusion-python-embed wheels to build

Also split the building of macos arm wheels into a separate CI job so that the mac build doesn't take extra long.