### PR TITLE
Change default mime type to "vega", add Colab and Kaggle support

### DIFF
--- a/python/vegafusion-jupyter/tests/test_conext_manager.py
+++ b/python/vegafusion-jupyter/tests/test_conext_manager.py
@@ -2,7 +2,7 @@ import altair as alt
 import vegafusion as vf
 
 
-def test_enabler_context_manager():
+def test_widget_enabler_context_manager():
     alt.data_transformers.enable("json")
     alt.renderers.enable("mimetype")
 
@@ -22,7 +22,7 @@ def test_enabler_context_manager():
     assert repr(ctx) == "vegafusion.enable_widget()"
 
 
-def test_enabler_context_manager_preserves_options():
+def test_widget_enabler_context_manager_preserves_options():
     # No options
     with vf.enable_widget():
         assert alt.data_transformers.active == "vegafusion-feather"

--- a/python/vegafusion/tests/test_conext_manager.py
+++ b/python/vegafusion/tests/test_conext_manager.py
@@ -2,7 +2,7 @@ import altair as alt
 import vegafusion as vf
 
 
-def test_enabler_context_manager():
+def test_mime_enabler_context_manager():
     alt.data_transformers.enable("json")
     alt.renderers.enable("mimetype")
 
@@ -31,4 +31,4 @@ def test_enabler_context_manager():
     ctx = vf.enable_mime()
     assert alt.data_transformers.active == "vegafusion-inline"
     assert alt.renderers.active == "vegafusion-mime"
-    assert repr(ctx) == "vegafusion.enable_mime(mimetype='html', embed_options=None)"
+    assert repr(ctx) == "vegafusion.enable_mime(mimetype='vega', embed_options=None)"

--- a/python/vegafusion/vegafusion/__init__.py
+++ b/python/vegafusion/vegafusion/__init__.py
@@ -45,7 +45,7 @@ def altair_vl_version(vl_convert=False):
         return SCHEMA_VERSION.rstrip("v")
 
 
-def enable_mime(mimetype="html", embed_options=None):
+def enable_mime(mimetype="vega", embed_options=None):
     """
     Enable the VegaFusion data transformer and renderer so that all Charts
     are displayed using VegaFusion.

--- a/python/vegafusion/vegafusion/__init__.py
+++ b/python/vegafusion/vegafusion/__init__.py
@@ -53,8 +53,10 @@ def enable_mime(mimetype="vega", embed_options=None):
     This isn't necessary in order to use the VegaFusionWidget directly
 
     :param mimetype: Mime type. One of:
-        - "html" (default)
-        - "vega"
+        - "vega" (default)
+        - "html"
+        - "html-colab" or "colab"
+        - "html-kaggle" or "kaggle
         - "svg"
         - "png": Note: the PNG renderer can be quite slow for charts with lots of marks
     :param embed_options: dict (optional)

--- a/python/vegafusion/vegafusion/renderer.py
+++ b/python/vegafusion/vegafusion/renderer.py
@@ -2,7 +2,7 @@ import altair as alt
 from altair.utils.html import spec_to_html
 
 
-def vegafusion_mime_renderer(spec, mimetype="html", embed_options=None):
+def vegafusion_mime_renderer(spec, mimetype="vega", embed_options=None):
     from . import transformer, runtime, local_tz, vegalite_compilers, altair_vl_version
     vega_spec = vegalite_compilers.get()(spec)
 

--- a/python/vegafusion/vegafusion/renderer.py
+++ b/python/vegafusion/vegafusion/renderer.py
@@ -42,6 +42,31 @@ def vegafusion_mime_renderer(spec, mimetype="vega", embed_options=None):
             embed_options=embed_options
         )
         return {"text/html": html}
+    elif mimetype == "html-colab" or mimetype == "colab":
+        html = spec_to_html(
+            tx_vega_spec,
+            mode="vega",
+            vega_version="5",
+            vegalite_version=altair_vl_version(),
+            vegaembed_version="6",
+            fullhtml=True,
+            requirejs=False,
+            output_div="altair-viz",
+            embed_options=embed_options
+        )
+        return {"text/html": html}
+    elif mimetype == "html-kaggle" or mimetype == "kaggle":
+        html = spec_to_html(
+            tx_vega_spec,
+            mode="vega",
+            vega_version="5",
+            vegalite_version=altair_vl_version(),
+            vegaembed_version="6",
+            fullhtml=False,
+            requirejs=True,
+            embed_options=embed_options
+        )
+        return {"text/html": html}
     elif mimetype == "svg":
         import vl_convert as vlc
         svg = vlc.vega_to_svg(tx_vega_spec)


### PR DESCRIPTION
This PR changes the default mimetype from `"html"` to `"vega"`. While `"html"` works in both the classic notebook and JupyterLab, it requires an active internet connection .  The `"vega"` type works in JupyterLab, Visual Studio Code, nteract, and other modern environments and does not require an internet connection.

It also adds (html-)colab and (html-)kaggle mime types that follow Altair's logic for supporting display in Colab and Kaggle notebooks.