### PR TITLE
Add configurable row limit for mime renderer

### DIFF
--- a/python/vegafusion/tests/test_conext_manager.py
+++ b/python/vegafusion/tests/test_conext_manager.py
@@ -31,4 +31,4 @@ def test_mime_enabler_context_manager():
     ctx = vf.enable_mime()
     assert alt.data_transformers.active == "vegafusion-inline"
     assert alt.renderers.active == "vegafusion-mime"
-    assert repr(ctx) == "vegafusion.enable_mime(mimetype='vega', embed_options=None)"
+    assert repr(ctx) == "vegafusion.enable_mime(mimetype='vega', row_limit=10000, embed_options=None)"

--- a/python/vegafusion/tests/test_row_limit.py
+++ b/python/vegafusion/tests/test_row_limit.py
@@ -1,0 +1,32 @@
+import pytest
+import vegafusion as vf
+import altair as alt
+from altair.utils.execeval import eval_block
+from pathlib import Path
+here = Path(__file__).parent
+altair_mocks_dir = here / "altair_mocks"
+
+
+def test_row_limit():
+    mock_path = altair_mocks_dir / "scatter" / "bubble_plot" / "mock.py"
+    mock_src = mock_path.read_text("utf8")
+    chart = eval_block(mock_src)
+
+    # Dataset has 406 rows (before filtering out nulls) and this chart is not aggregated.
+    # Limit of 500 rows should be fine
+    with vf.enable_mime(row_limit=500):
+        chart._repr_mimebundle_()
+
+    # Limit of 300 rows should raise RowLimitError
+    with vf.enable_mime(row_limit=300):
+        with pytest.raises(vf.RowLimitError):
+            chart._repr_mimebundle_()
+
+    # Adding an aggregation should allow row limit to be much lower
+    chart = chart.encode(
+        alt.X("Horsepower", bin=True),
+        alt.Y("Miles_per_Gallon", bin=True),
+        alt.Size("count()")
+    )
+    with vf.enable_mime(row_limit=50):
+        chart._repr_mimebundle_()

--- a/python/vegafusion/vegafusion/__init__.py
+++ b/python/vegafusion/vegafusion/__init__.py
@@ -6,6 +6,7 @@
 # this program the details of the active license.
 from .runtime import runtime
 from .transformer import to_feather, get_inline_datasets_for_spec
+from .renderer import RowLimitError
 from .local_tz import set_local_tz, get_local_tz
 from .evaluation import transformed_data
 from . import renderer
@@ -45,7 +46,7 @@ def altair_vl_version(vl_convert=False):
         return SCHEMA_VERSION.rstrip("v")
 
 
-def enable_mime(mimetype="vega", embed_options=None):
+def enable_mime(mimetype="vega", row_limit=10000, embed_options=None):
     """
     Enable the VegaFusion data transformer and renderer so that all Charts
     are displayed using VegaFusion.
@@ -57,16 +58,23 @@ def enable_mime(mimetype="vega", embed_options=None):
         - "html"
         - "svg"
         - "png": Note: the PNG renderer can be quite slow for charts with lots of marks
+    :param row_limit: Maximum number of rows (after transforms are applied) that may be
+        included in the Vega specifications that will be displayed. An error will
+        be raised if the limit is exceeded. None for unlimited.
     :param embed_options: dict (optional)
         Dictionary of options to pass to the vega-embed. Default
         entry is {'mode': 'vega'}.
     """
     return RendererTransformerEnabler(
         renderer_ctx=alt.renderers.enable(
-            'vegafusion-mime', mimetype=mimetype, embed_options=embed_options
+            'vegafusion-mime', mimetype=mimetype, row_limit=row_limit, embed_options=embed_options
         ),
         data_transformer_ctx=alt.data_transformers.enable('vegafusion-inline'),
-        repr_str=f"vegafusion.enable_mime(mimetype={repr(mimetype)}, embed_options={repr(embed_options)})"
+        repr_str=(
+            "vegafusion.enable_mime("
+            f"mimetype={repr(mimetype)}, row_limit={row_limit}, embed_options={repr(embed_options)}"
+            ")"
+        )
     )
 
 


### PR DESCRIPTION
This PR adds a new `row_limit` argument to the `vf.enable_mime()` function that is used to specify the maximum number of rows (after transforms are applied) that are allowed to be inlined into the Vega specification that will be sent to the client.  

```python
import vegafusion as vf
vf.enable_mime(row_limit=10000)
...
chart
```

The default limit is 10,000

Like Altair's built-in RowLimit, this is to protect users from accidentally crashing their browser. But unlike regular Altair, this limit is enforced after the Chart's transforms have been applied.  The error message advises users that they can get around the error by introducing an aggregation or raising the `row_limit` argument to the `enable_mime` function.
