### PR TITLE
Localize/convert transformed_data datetimes to local_tz

### DIFF
--- a/python/vegafusion/tests/test_pretransform.py
+++ b/python/vegafusion/tests/test_pretransform.py
@@ -909,11 +909,11 @@ def test_date32_pre_transform_dataset():
         spec, ["data_0"], "America/New_York", default_input_tz="UTC", inline_datasets=dict(dates=dates_df)
     )
 
-    # Timestamps are always in UTC, so we're checking that they would convert to midnight local time
+    # Timestamps are in the local timezone, so they should be midnight local time
     assert list(output_ds.date_col) == [
-        pd.Timestamp('2022-01-01 05:00:00'),
-        pd.Timestamp('2022-01-02 05:00:00'),
-        pd.Timestamp('2022-01-03 05:00:00')
+        pd.Timestamp('2022-01-01 00:00:00-0500', tz='America/New_York'),
+        pd.Timestamp('2022-01-02 00:00:00-0500', tz='America/New_York'),
+        pd.Timestamp('2022-01-03 00:00:00-0500', tz='America/New_York')
     ]
 
 
@@ -934,27 +934,27 @@ def test_nat_values():
     dataframe = pd.DataFrame([
         {'ORDER_DATE': date(2011, 3, 1),
          'SALES': 457.568,
-         'NULL_TEST': Timestamp('2011-03-01 00:00:00')},
+         'NULL_TEST': Timestamp('2011-03-01 00:00:00+0000', tz="UTC")},
         {'ORDER_DATE': date(2011, 3, 1),
          'SALES': 376.509,
-         'NULL_TEST': Timestamp('2011-03-01 00:00:00')},
+         'NULL_TEST': Timestamp('2011-03-01 00:00:00+0000', tz="UTC")},
         {'ORDER_DATE': date(2011, 3, 1),
          'SALES': 362.25,
-         'NULL_TEST': Timestamp('2011-03-01 00:00:00')},
+         'NULL_TEST': Timestamp('2011-03-01 00:00:00+0000', tz="UTC")},
         {'ORDER_DATE': date(2011, 3, 1),
          'SALES': 129.552,
-         'NULL_TEST': Timestamp('2011-03-01 00:00:00')},
+         'NULL_TEST': Timestamp('2011-03-01 00:00:00+0000', tz="UTC")},
         {'ORDER_DATE': date(2011, 3, 1), 'SALES': 18.84, 'NULL_TEST': NaT},
         {'ORDER_DATE': date(2011, 4, 1),
          'SALES': 66.96,
-         'NULL_TEST': Timestamp('2011-04-01 00:00:00')},
+         'NULL_TEST': Timestamp('2011-04-01 00:00:00+0000', tz="UTC")},
         {'ORDER_DATE': date(2011, 4, 1), 'SALES': 6.24, 'NULL_TEST': NaT},
         {'ORDER_DATE': date(2011, 6, 1),
          'SALES': 881.93,
-         'NULL_TEST': Timestamp('2011-06-01 00:00:00')},
+         'NULL_TEST': Timestamp('2011-06-01 00:00:00+0000', tz="UTC")},
         {'ORDER_DATE': date(2011, 6, 1),
          'SALES': 166.72,
-         'NULL_TEST': Timestamp('2011-06-01 00:00:00')},
+         'NULL_TEST': Timestamp('2011-06-01 00:00:00+0000', tz="UTC")},
         {'ORDER_DATE': date(2011, 6, 1), 'SALES': 25.92, 'NULL_TEST': NaT}
     ])
 
@@ -968,8 +968,8 @@ def test_nat_values():
 
     dataset = datasets[0]
     assert dataset.to_dict("records")[0] == {
-        'NULL_TEST': pd.Timestamp('2011-03-01 00:00:00'),
-        'ORDER_DATE': Timestamp('2011-03-01 00:00:00'),
+        'NULL_TEST': pd.Timestamp('2011-03-01 00:00:00+0000', tz="UTC"),
+        'ORDER_DATE': Timestamp('2011-03-01 00:00:00+0000', tz="UTC"),
         'SALES': 457.568,
         'SALES_end': 457.568,
         'SALES_start': 0.0,

--- a/python/vegafusion/tests/test_transformed_data.py
+++ b/python/vegafusion/tests/test_transformed_data.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytz
 import pytest
 from altair.utils.execeval import eval_block
 import vegafusion as vf
@@ -97,6 +98,11 @@ def test_transformed_data_for_mock(mock_name, expected_len, expected_cols):
 
     # Check that the expected columns are present
     assert set(expected_cols).issubset(set(df.columns))
+
+    # Check that datetime columns have UTC timezone
+    for dtype in df.dtypes.values:
+        if dtype.kind == "M":
+            assert dtype.tz == pytz.timezone(vf.get_local_tz())
 
     # Check expected length
     assert len(df) == expected_len

--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -147,6 +147,7 @@ class VegaFusionRuntime:
                    key indicating the warning type, and a 'message' key containing
                    a description of the warning.
         """
+        from . import get_local_tz
         if self._grpc_channel:
             raise ValueError("pre_transform_datasets not yet supported over gRPC")
         else:
@@ -178,6 +179,12 @@ class VegaFusionRuntime:
 
             # Deserialize values to Arrow tables
             datasets = [pa.ipc.deserialize_pandas(value) for value in values]
+
+            # Localize datetime columns to UTC
+            for df in datasets:
+                for name, dtype in df.dtypes.items():
+                    if dtype.kind == "M":
+                        df[name] = df[name].dt.tz_localize("UTC").dt.tz_convert(get_local_tz())
 
             return datasets, warnings
 

--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -147,7 +147,6 @@ class VegaFusionRuntime:
                    key indicating the warning type, and a 'message' key containing
                    a description of the warning.
         """
-        from . import get_local_tz
         if self._grpc_channel:
             raise ValueError("pre_transform_datasets not yet supported over gRPC")
         else:
@@ -184,7 +183,7 @@ class VegaFusionRuntime:
             for df in datasets:
                 for name, dtype in df.dtypes.items():
                     if dtype.kind == "M":
-                        df[name] = df[name].dt.tz_localize("UTC").dt.tz_convert(get_local_tz())
+                        df[name] = df[name].dt.tz_localize("UTC").dt.tz_convert(local_tz)
 
             return datasets, warnings
 


### PR DESCRIPTION
Previously datetime columns returned by `vf.transformed_data` were naive but implicitly in the UTC timezone.  This PR localizes them as UTC then converts them to VegaFusion's local timezone.

For example:


```python
import vegafusion as vf
import altair as alt
from vega_datasets import data

# Manually set timezone to Seattle's since this a seattle weather
# dataset
vf.set_local_tz("America/Los_Angeles")

source = data.seattle_weather()

chart = alt.Chart(source).mark_bar(
    cornerRadiusTopLeft=3,
    cornerRadiusTopRight=3
).encode(
    x='month(date):O',
    y='count():Q',
    color='weather:N'
)
chart
```
![visualization](https://user-images.githubusercontent.com/15064365/210239728-020244de-15c3-4b2d-89fc-1b33b89c9b1d.png)

```python
tx_df = vf.transformed_data(chart, row_limit=5)
tx_df
```

|    | weather   | month_date                |   __count |   __count_start |   __count_end |
|---:|:----------|:--------------------------|----------:|----------------:|--------------:|
|  0 | drizzle   | 2012-01-01 00:00:00-08:00 |        10 |             114 |           124 |
|  1 | rain      | 2012-01-01 00:00:00-08:00 |        35 |              41 |            76 |
|  2 | sun       | 2012-01-01 00:00:00-08:00 |        33 |               0 |            33 |
|  3 | snow      | 2012-01-01 00:00:00-08:00 |         8 |              33 |            41 |
|  4 | rain      | 2012-02-01 00:00:00-08:00 |        40 |              33 |            73 |

```python
tx_df.dtypes
```
```
weather                                       object
month_date       datetime64[ns, America/Los_Angeles]
__count                                        int64
__count_start                                  int64
__count_end                                    int64
dtype: object
```