### PR TITLE
Default renderer back to "html" for consistency with Altair

### DIFF
--- a/python/vegafusion/tests/test_conext_manager.py
+++ b/python/vegafusion/tests/test_conext_manager.py
@@ -31,4 +31,4 @@ def test_mime_enabler_context_manager():
     ctx = vf.enable_mime()
     assert alt.data_transformers.active == "vegafusion-inline"
     assert alt.renderers.active == "vegafusion-mime"
-    assert repr(ctx) == "vegafusion.enable_mime(mimetype='vega', row_limit=10000, embed_options=None)"
+    assert repr(ctx) == "vegafusion.enable_mime(mimetype='html', row_limit=10000, embed_options=None)"

--- a/python/vegafusion/vegafusion/__init__.py
+++ b/python/vegafusion/vegafusion/__init__.py
@@ -46,7 +46,7 @@ def altair_vl_version(vl_convert=False):
         return SCHEMA_VERSION.rstrip("v")
 
 
-def enable_mime(mimetype="vega", row_limit=10000, embed_options=None):
+def enable_mime(mimetype="html", row_limit=10000, embed_options=None):
     """
     Enable the VegaFusion data transformer and renderer so that all Charts
     are displayed using VegaFusion.
@@ -54,10 +54,10 @@ def enable_mime(mimetype="vega", row_limit=10000, embed_options=None):
     This isn't necessary in order to use the VegaFusionWidget directly
 
     :param mimetype: Mime type. One of:
-        - "vega" (default)
-        - "html"
+        - "html" (default)
+        - "vega"
         - "svg"
-        - "png": Note: the PNG renderer can be quite slow for charts with lots of marks
+        - "png": Note, the PNG renderer can be quite slow for charts with lots of marks
     :param row_limit: Maximum number of rows (after transforms are applied) that may be
         included in the Vega specifications that will be displayed. An error will
         be raised if the limit is exceeded. None for unlimited.

--- a/python/vegafusion/vegafusion/renderer.py
+++ b/python/vegafusion/vegafusion/renderer.py
@@ -14,7 +14,7 @@ class RowLimitError(ValueError):
         )
 
 
-def vegafusion_mime_renderer(spec, mimetype="vega", row_limit=None, embed_options=None):
+def vegafusion_mime_renderer(spec, mimetype="html", row_limit=None, embed_options=None):
     from . import transformer, runtime, local_tz, vegalite_compilers, altair_vl_version
     vega_spec = vegalite_compilers.get()(spec)
 


### PR DESCRIPTION
This PR changes the default mime renderer mimetype to "html".

This is consistent with Altair's default, and so should be less surprising for users who have never had to think about mimetypes.