### PR TITLE
Rename enable_mime() to enable()

### DIFF
--- a/python/vegafusion-jupyter/tests/test_altair_mocks.py
+++ b/python/vegafusion-jupyter/tests/test_altair_mocks.py
@@ -85,7 +85,7 @@ vegafusion_mime_markdown_template = r"""
 ```python
 import altair as alt
 import vegafusion as vf
-vf.enable_mime(mimetype="html", embed_options={'actions': False})
+vf.enable(mimetype="html", embed_options={'actions': False})
 ```
 
 ```python

--- a/python/vegafusion/tests/test_conext_manager.py
+++ b/python/vegafusion/tests/test_conext_manager.py
@@ -21,14 +21,14 @@ def test_mime_enabler_context_manager():
     assert alt.renderers.active == "default"
     assert repr(ctx) == "vegafusion.disable()"
 
-    with vf.enable_mime():
+    with vf.enable():
         assert alt.data_transformers.active == "vegafusion-inline"
         assert alt.renderers.active == "vegafusion-mime"
 
     assert alt.data_transformers.active == "default"
     assert alt.renderers.active == "default"
 
-    ctx = vf.enable_mime()
+    ctx = vf.enable()
     assert alt.data_transformers.active == "vegafusion-inline"
     assert alt.renderers.active == "vegafusion-mime"
-    assert repr(ctx) == "vegafusion.enable_mime(mimetype='html', row_limit=10000, embed_options=None)"
+    assert repr(ctx) == "vegafusion.enable(mimetype='html', row_limit=10000, embed_options=None)"

--- a/python/vegafusion/tests/test_row_limit.py
+++ b/python/vegafusion/tests/test_row_limit.py
@@ -14,11 +14,11 @@ def test_row_limit():
 
     # Dataset has 406 rows (before filtering out nulls) and this chart is not aggregated.
     # Limit of 500 rows should be fine
-    with vf.enable_mime(row_limit=500):
+    with vf.enable(row_limit=500):
         chart._repr_mimebundle_()
 
     # Limit of 300 rows should raise RowLimitError
-    with vf.enable_mime(row_limit=300):
+    with vf.enable(row_limit=300):
         with pytest.raises(vf.RowLimitError):
             chart._repr_mimebundle_()
 
@@ -28,5 +28,5 @@ def test_row_limit():
         alt.Y("Miles_per_Gallon", bin=True),
         alt.Size("count()")
     )
-    with vf.enable_mime(row_limit=50):
+    with vf.enable(row_limit=50):
         chart._repr_mimebundle_()

--- a/python/vegafusion/vegafusion/__init__.py
+++ b/python/vegafusion/vegafusion/__init__.py
@@ -46,12 +46,10 @@ def altair_vl_version(vl_convert=False):
         return SCHEMA_VERSION.rstrip("v")
 
 
-def enable_mime(mimetype="html", row_limit=10000, embed_options=None):
+def enable(mimetype="html", row_limit=10000, embed_options=None):
     """
-    Enable the VegaFusion data transformer and renderer so that all Charts
+    Enable the VegaFusion mime renderer so that all Altair charts
     are displayed using VegaFusion.
-
-    This isn't necessary in order to use the VegaFusionWidget directly
 
     :param mimetype: Mime type. One of:
         - "html" (default)
@@ -71,7 +69,7 @@ def enable_mime(mimetype="html", row_limit=10000, embed_options=None):
         ),
         data_transformer_ctx=alt.data_transformers.enable('vegafusion-inline'),
         repr_str=(
-            "vegafusion.enable_mime("
+            "vegafusion.enable("
             f"mimetype={repr(mimetype)}, row_limit={row_limit}, embed_options={repr(embed_options)}"
             ")"
         )

--- a/python/vegafusion/vegafusion/__init__.py
+++ b/python/vegafusion/vegafusion/__init__.py
@@ -79,11 +79,23 @@ def enable_mime(mimetype="html", row_limit=10000, embed_options=None):
 
 
 def enable_widget(
-    download_source_link=None,
     debounce_wait=30,
     debounce_max_wait=60,
-    data_dir="_vegafusion_data"
+    data_dir="_vegafusion_data",
+    download_source_link=None,
 ):
+    """
+    Enable the VegaFusion widget renderer so that all charts are displayed
+    using VegaFusion.
+
+    This isn't necessary in order to use the VegaFusionWidget directly
+
+    :param debounce_wait: Debounce wait period for interactions (milliseconds)
+    :param debounce_max_wait: Max debounce wait for interactions (milliseconds)
+    :param download_source_link: URL of notebooks source code for inclusion
+        in dropdown menu
+    :param data_dir: Path that temporary feather files will be written to
+    """
     from vegafusion.jupyter import enable
     return enable(
         download_source_link=download_source_link,

--- a/python/vegafusion/vegafusion/renderer.py
+++ b/python/vegafusion/vegafusion/renderer.py
@@ -10,7 +10,7 @@ class RowLimitError(ValueError):
         return (
             f"Limit of {self.row_limit} rows was exceeded.\n"
             "Either introduce an aggregation to reduce the number of rows sent to the client or\n"
-            "increase the row_limit argument to the vegafusion.enable_mime() function"
+            "increase the row_limit argument to the vegafusion.enable() function"
         )
 
 


### PR DESCRIPTION
This PR renames the `vf.enable_mime()` function to simply `vf.enable()`.

This is to remove an early point of confusion for users who aren't familiar with the term mime(type).  There is still a `mimetype` argument to the function, but it will default to `html` so a user isn't forced to deal with it in most cases.

The `enable_widget()` function stays as is.  I considered merging it into `vf.enable()`, but the widget renderer has several distinct configuration options that would complicate the signature of `vf.enable` with options that are only valid for the widget renderer.