### PR TITLE
Fix distinct aggregation with nulls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,8 +86,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed9849f86164fad5cb66ce4732782b15f1bc97f8febab04e782c20cce9d4b6c"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "ahash 0.8.0",
  "arrow-array",
@@ -114,8 +113,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8504cf0a6797e908eecf221a865e7d339892720587f87c8b90262863015b08"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "ahash 0.8.0",
  "arrow-buffer",
@@ -130,8 +128,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6de64a27cea684b24784647d9608314bc80f7c4d55acb44a425e05fab39d916"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "half 2.1.0",
  "num",
@@ -140,8 +137,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec4a54502eefe05923c385c90a005d69474fa06ca7aa2a2b123c9f9532f6178"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -156,8 +152,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7902bbf8127eac48554fe902775303377047ad49a9fd473c2b8cb399d092080"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -174,8 +169,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4882efe617002449d5c6b5de9ddb632339074b36df8a96ea7147072f1faa8a"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -186,8 +180,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0703a6de2785828561b03a4d7793ecd333233e1b166316b4bfc7cfce55a4a7"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -200,8 +193,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd23fc8c6d251f96cd63b96fece56bbb9710ce5874a627cb786e2600673595a"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -218,14 +210,12 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f143882a80be168538a60e298546314f50f11f2a288c8d73e11108da39d26"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 
 [[package]]
 name = "arrow-select"
 version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520406331d4ad60075359524947ebd804e479816439af82bcb17f8d280d9b38c"
+source = "git+https://github.com/jonmmease/arrow-rs.git?rev=b7a162a8818aa6ded704edec5d7423ee4645e9e2#b7a162a8818aa6ded704edec5d7423ee4645e9e2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,20 @@ members = [
 ## Tell `rustc` to use highest performance optimization and perform Link Time Optimization
 opt-level = 3
 # lto = true
+
+[patch.crates-io]
+
+# Arrow 28.0 with backports
+arrow = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+arrow-cast = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+arrow-ipc = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+arrow-data = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+arrow-buffer = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+arrow-schema = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+arrow-array = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+arrow-select = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "b7a162a8818aa6ded704edec5d7423ee4645e9e2"}
+
+# DataFusion 15.0 with backports
+datafusion = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"}
+datafusion-common = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"}
+datafusion-expr = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"}

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -37,8 +37,7 @@ default_features = false
 features = [ "ipc", "json",]
 
 [dependencies.datafusion-common]
-git = "https://github.com/jonmmease/arrow-datafusion.git"
-rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
+version = "~15.0.0"
 
 [dependencies.pyo3]
 version = "0.17.1"

--- a/vegafusion-rt-datafusion/Cargo.toml
+++ b/vegafusion-rt-datafusion/Cargo.toml
@@ -73,12 +73,10 @@ version = "1.0.137"
 features = [ "derive",]
 
 [dependencies.datafusion]
-git = "https://github.com/jonmmease/arrow-datafusion.git"
-rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
+version = "~15.0.0"
 
 [dependencies.datafusion-expr]
-git = "https://github.com/jonmmease/arrow-datafusion.git"
-rev = "45214e5ff61c5603d696f5a2bc8c297e4bd6b7b6"
+version = "~15.0.0"
 
 [dependencies.tokio]
 version = "1.18.1"

--- a/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
@@ -15,8 +15,8 @@ use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_core::spec::values::{Field, SignalExpressionSpec};
 
 mod test_aggregate_single {
-    use crate::*;
     use crate::util::check::eval_vegafusion_transforms;
+    use crate::*;
 
     #[rstest(
         op,
@@ -29,7 +29,7 @@ mod test_aggregate_single {
         case(AggregateOpSpec::Average),
         case(AggregateOpSpec::Min),
         case(AggregateOpSpec::Max),
-        case(AggregateOpSpec::Median),
+        case(AggregateOpSpec::Median)
     )]
     fn test(op: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");
@@ -51,11 +51,7 @@ mod test_aggregate_single {
         if matches!(op, AggregateOpSpec::Distinct) {
             // Vega counts null as distinct category but DataFusion does not.
             // Just make sure it doesn't crash
-            eval_vegafusion_transforms(
-                &dataset,
-                transform_specs.as_slice(),
-                &comp_config,
-            );
+            eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
         } else {
             let eq_config = TablesEqualConfig {
                 row_order: false,
@@ -73,11 +69,12 @@ mod test_aggregate_single {
 }
 
 mod test_aggregate_multi {
-    use crate::*;
     use crate::util::check::eval_vegafusion_transforms;
+    use crate::*;
 
     #[rstest(
-        op1, op2,
+        op1,
+        op2,
         case(AggregateOpSpec::Count, AggregateOpSpec::Count),
         case(AggregateOpSpec::Valid, AggregateOpSpec::Missing),
         case(AggregateOpSpec::Missing, AggregateOpSpec::Valid),
@@ -87,7 +84,7 @@ mod test_aggregate_multi {
         case(AggregateOpSpec::Average, AggregateOpSpec::Mean),
         case(AggregateOpSpec::Min, AggregateOpSpec::Average),
         case(AggregateOpSpec::Max, AggregateOpSpec::Min),
-        case(AggregateOpSpec::Median, AggregateOpSpec::Average),
+        case(AggregateOpSpec::Median, AggregateOpSpec::Average)
     )]
     fn test(op1: AggregateOpSpec, op2: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");
@@ -114,11 +111,7 @@ mod test_aggregate_multi {
 
         if matches!(op1, AggregateOpSpec::Distinct) || matches!(op2, AggregateOpSpec::Distinct) {
             // Vega counts null as distinct category but DataFusion does not
-            eval_vegafusion_transforms(
-                &dataset,
-                transform_specs.as_slice(),
-                &comp_config,
-            );
+            eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
         } else {
             // Order of grouped rows is not defined, so set row_order to false
             let eq_config = TablesEqualConfig {
@@ -133,7 +126,6 @@ mod test_aggregate_multi {
                 &eq_config,
             );
         }
-
     }
 }
 
@@ -238,30 +230,33 @@ fn test_aggregate_overwrite() {
     );
 }
 
-
 mod test_aggregate_with_nulls {
+    use crate::util::check::eval_vegafusion_transforms;
+    use crate::*;
     use serde_json::json;
     use vegafusion_core::data::table::VegaFusionTable;
-    use crate::*;
-    use crate::util::check::eval_vegafusion_transforms;
 
     #[rstest(
-    op,
-    case(AggregateOpSpec::Count),
-    case(AggregateOpSpec::Valid),
-    case(AggregateOpSpec::Missing),
-    case(AggregateOpSpec::Distinct),
+        op,
+        case(AggregateOpSpec::Count),
+        case(AggregateOpSpec::Valid),
+        case(AggregateOpSpec::Missing),
+        case(AggregateOpSpec::Distinct)
     )]
     fn test(op: AggregateOpSpec) {
-        let dataset = VegaFusionTable::from_json(&json!(
-            [
-                {"SHIP": "A", "NULL_ORDER_IDS": null},
-                {"SHIP": "B", "NULL_ORDER_IDS": "CA-2011-168312"},
-                {"SHIP": "C", "NULL_ORDER_IDS": "CA-2011-131009"},
-                {"SHIP": "D", "NULL_ORDER_IDS": "CA-2011-131009"},
-                {"SHIP": "E", "NULL_ORDER_IDS": "CA-2011-131009"}
-            ]
-        ), 1024).unwrap();
+        let dataset = VegaFusionTable::from_json(
+            &json!(
+                [
+                    {"SHIP": "A", "NULL_ORDER_IDS": null},
+                    {"SHIP": "B", "NULL_ORDER_IDS": "CA-2011-168312"},
+                    {"SHIP": "C", "NULL_ORDER_IDS": "CA-2011-131009"},
+                    {"SHIP": "D", "NULL_ORDER_IDS": "CA-2011-131009"},
+                    {"SHIP": "E", "NULL_ORDER_IDS": "CA-2011-131009"}
+                ]
+            ),
+            1024,
+        )
+        .unwrap();
 
         let aggregate_spec = AggregateTransformSpec {
             groupby: vec![Field::String("SHIP".to_string())],
@@ -281,11 +276,7 @@ mod test_aggregate_with_nulls {
         if matches!(op, AggregateOpSpec::Distinct) {
             // Vega counts null as distinct category but DataFusion does not.
             // Just make sure it doesn't crash
-            eval_vegafusion_transforms(
-                &dataset,
-                transform_specs.as_slice(),
-                &comp_config,
-            );
+            eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
         } else {
             let eq_config = TablesEqualConfig {
                 row_order: false,

--- a/vegafusion-rt-datafusion/tests/util/check.rs
+++ b/vegafusion-rt-datafusion/tests/util/check.rs
@@ -118,7 +118,7 @@ pub fn eval_vegafusion_transforms(
     let sql_df = (*TOKIO_RUNTIME).block_on(data.to_sql_dataframe()).unwrap();
 
     let (result_data, result_signals) = TOKIO_RUNTIME
-        .block_on(pipeline.eval_sql(sql_df, &compilation_config))
+        .block_on(pipeline.eval_sql(sql_df, compilation_config))
         .unwrap();
     let result_signals = result_signals
         .into_iter()

--- a/vegafusion-rt-datafusion/tests/util/check.rs
+++ b/vegafusion-rt-datafusion/tests/util/check.rs
@@ -96,7 +96,8 @@ pub fn check_transform_evaluation(
     // );
     // println!("expected signals: {:?}", expected_signals);
 
-    let (result_data, result_signals) = eval_vegafusion_transforms(data, transform_specs, &compilation_config);
+    let (result_data, result_signals) =
+        eval_vegafusion_transforms(data, transform_specs, &compilation_config);
 
     // println!(
     //     "result data\n{}",
@@ -111,7 +112,7 @@ pub fn check_transform_evaluation(
 pub fn eval_vegafusion_transforms(
     data: &VegaFusionTable,
     transform_specs: &[TransformSpec],
-    compilation_config: &CompilationConfig
+    compilation_config: &CompilationConfig,
 ) -> (VegaFusionTable, Vec<ScalarValue>) {
     let pipeline = TransformPipeline::try_from(transform_specs).unwrap();
     let sql_df = (*TOKIO_RUNTIME).block_on(data.to_sql_dataframe()).unwrap();

--- a/vegafusion-rt-datafusion/tests/util/check.rs
+++ b/vegafusion-rt-datafusion/tests/util/check.rs
@@ -96,6 +96,23 @@ pub fn check_transform_evaluation(
     // );
     // println!("expected signals: {:?}", expected_signals);
 
+    let (result_data, result_signals) = eval_vegafusion_transforms(data, transform_specs, &compilation_config);
+
+    // println!(
+    //     "result data\n{}",
+    //     result_data.pretty_format(Some(500)).unwrap()
+    // );
+    // println!("result signals: {:?}", result_signals);
+
+    assert_tables_equal(&result_data, &expected_data, equality_config);
+    assert_signals_almost_equal(result_signals, expected_signals, equality_config.tolerance);
+}
+
+pub fn eval_vegafusion_transforms(
+    data: &VegaFusionTable,
+    transform_specs: &[TransformSpec],
+    compilation_config: &CompilationConfig
+) -> (VegaFusionTable, Vec<ScalarValue>) {
     let pipeline = TransformPipeline::try_from(transform_specs).unwrap();
     let sql_df = (*TOKIO_RUNTIME).block_on(data.to_sql_dataframe()).unwrap();
 
@@ -107,13 +124,5 @@ pub fn check_transform_evaluation(
         .map(|v| v.as_scalar().map(|v| v.clone()))
         .collect::<Result<Vec<ScalarValue>>>()
         .unwrap();
-
-    // println!(
-    //     "result data\n{}",
-    //     result_data.pretty_format(Some(500)).unwrap()
-    // );
-    // println!("result signals: {:?}", result_signals);
-
-    assert_tables_equal(&result_data, &expected_data, equality_config);
-    assert_signals_almost_equal(result_signals, expected_signals, equality_config.tolerance);
+    (result_data, result_signals)
 }


### PR DESCRIPTION
This fixes PR fixes the following errors with aggregating a column with nulls using the `distinct` aggregation operation

```
PanicException: Failed to get node value: DataFusionError(ArrowError(ExternalError(ArrowError(ExternalError(Internal("Unexpected accumulator state List([NULL])"))))), ErrorContext { contexts: [] })
```

```
InvalidArgumentError("Column 'COUNT(DISTINCT tbl.col2)[count distinct]' is declared as non-nullable but contains null values")
```

The root cause was an issue in `arrow-rs`: https://github.com/apache/arrow-rs/issues/3471. Also, see the DataFusion issue: https://github.com/apache/arrow-datafusion/issues/4828.

Proposed fix in arrow was opened in https://github.com/apache/arrow-rs/pull/3473.

To take advantage of the fix immediately, I created a custom branch based on arrow 28.0 (The version that DataFusion 15.0 depends on) and cherry picked these commits onto it. This custom branch is at https://github.com/jonmmease/arrow-rs/pull/1. The Custom DataFusion branch we're currently using is at https://github.com/jonmmease/arrow-datafusion/pull/124.

This PR also switches to using cargo's [patch](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html) capability to override both the Arrow and DataFusion dependencies.  This way all of the git info for the custom branches is in one place.