### PR TITLE
Improve transform ordering using explicit ordering column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1d8c71a4703d27564c1a2bd60b164769f33fbe8f#1d8c71a4703d27564c1a2bd60b164769f33fbe8f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -985,7 +985,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1d8c71a4703d27564c1a2bd60b164769f33fbe8f#1d8c71a4703d27564c1a2bd60b164769f33fbe8f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
 dependencies = [
  "arrow",
  "chrono",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1d8c71a4703d27564c1a2bd60b164769f33fbe8f#1d8c71a4703d27564c1a2bd60b164769f33fbe8f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1d8c71a4703d27564c1a2bd60b164769f33fbe8f#1d8c71a4703d27564c1a2bd60b164769f33fbe8f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1d8c71a4703d27564c1a2bd60b164769f33fbe8f#1d8c71a4703d27564c1a2bd60b164769f33fbe8f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1d8c71a4703d27564c1a2bd60b164769f33fbe8f#1d8c71a4703d27564c1a2bd60b164769f33fbe8f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1d8c71a4703d27564c1a2bd60b164769f33fbe8f#1d8c71a4703d27564c1a2bd60b164769f33fbe8f"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
 dependencies = [
  "arrow-schema",
  "datafusion-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ arrow-array = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "59a528
 arrow-select = { git = "https://github.com/jonmmease/arrow-rs.git", rev = "59a5289b3603db08433e5309eed488a0abbf5d0d"}
 
 # DataFusion 16.0 with backports
-datafusion = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "1d8c71a4703d27564c1a2bd60b164769f33fbe8f"}
-datafusion-common = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "1d8c71a4703d27564c1a2bd60b164769f33fbe8f"}
-datafusion-expr = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "1d8c71a4703d27564c1a2bd60b164769f33fbe8f"}
+datafusion = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "e3f156f4acc51fc45a7aa6a99085b091f539d5fa"}
+datafusion-common = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "e3f156f4acc51fc45a7aa6a99085b091f539d5fa"}
+datafusion-expr = { git = "https://github.com/jonmmease/arrow-datafusion.git", rev = "e3f156f4acc51fc45a7aa6a99085b091f539d5fa"}

--- a/python/vegafusion/vegafusion/transformer.py
+++ b/python/vegafusion/vegafusion/transformer.py
@@ -67,8 +67,9 @@ def to_arrow_table(data):
                 except IndexError:
                     pass
 
-    # Convert DataFrame to table
-    table = pa.Table.from_pandas(data)
+    # Convert DataFrame to table. Keep index only if named
+    preserve_index = bool([name for name in getattr(data.index, "names", []) if name])
+    table = pa.Table.from_pandas(data, preserve_index=preserve_index)
 
     return table
 

--- a/vegafusion-core/src/data/mod.rs
+++ b/vegafusion-core/src/data/mod.rs
@@ -1,4 +1,9 @@
+use arrow::datatypes::DataType;
+
 pub mod json_writer;
 pub mod scalar;
 pub mod table;
 pub mod tasks;
+
+const ORDER_COL: &str = "_vf_order";
+const ORDER_COL_DTYPE: DataType = DataType::UInt32;

--- a/vegafusion-core/src/data/mod.rs
+++ b/vegafusion-core/src/data/mod.rs
@@ -5,5 +5,5 @@ pub mod scalar;
 pub mod table;
 pub mod tasks;
 
-const ORDER_COL: &str = "_vf_order";
-const ORDER_COL_DTYPE: DataType = DataType::UInt32;
+pub const ORDER_COL: &str = "_vf_order";
+pub const ORDER_COL_DTYPE: DataType = DataType::UInt32;

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -27,7 +27,7 @@ pub struct ImputeTransformSpec {
     pub groupby: Option<Vec<Field>>,
 
     // Default to zero but serialize even if null
-    #[serde(default="default_value")]
+    #[serde(default = "default_value")]
     pub value: Option<Value>,
 
     #[serde(flatten)]

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -63,7 +63,6 @@ impl TransformSpecTrait for ImputeTransformSpec {
             && self.keyvals.is_none()
             && self.method() == ImputeMethodSpec::Value
             && num_unique_groupby <= 1
-            && self.value.is_some()
     }
 
     fn transform_columns(

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+fn default_value() -> Option<Value> {
+    Some(Value::Number(serde_json::Number::from(0)))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ImputeTransformSpec {
     pub field: Field,
@@ -22,7 +26,8 @@ pub struct ImputeTransformSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub groupby: Option<Vec<Field>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Default to zero but serialize even if null
+    #[serde(default="default_value")]
     pub value: Option<Value>,
 
     #[serde(flatten)]

--- a/vegafusion-rt-datafusion/src/data/tasks.rs
+++ b/vegafusion-rt-datafusion/src/data/tasks.rs
@@ -110,8 +110,13 @@ impl TaskCall for DataUrlTask {
             let inline_name = inline_name.trim().to_string();
             if let Some(inline_dataset) = inline_datasets.get(&inline_name) {
                 let sql_df = match inline_dataset {
-                    VegaFusionDataset::Table { table, .. } => table.to_sql_dataframe().await?,
-                    VegaFusionDataset::SqlDataFrame(sql_df) => sql_df.clone(),
+                    VegaFusionDataset::Table { table, .. } => {
+                        table.clone().with_ordering()?.to_sql_dataframe().await?
+                    },
+                    VegaFusionDataset::SqlDataFrame(sql_df) => {
+                        // TODO: if no ordering column present, create with a window expression
+                        sql_df.clone()
+                    },
                 };
                 let sql_df = process_datetimes(&parse, sql_df, &config.tz_config).await?;
                 return eval_sql_df(sql_df.clone(), &self.pipeline, &config).await;

--- a/vegafusion-rt-datafusion/src/transform/aggregate.rs
+++ b/vegafusion-rt-datafusion/src/transform/aggregate.rs
@@ -9,11 +9,8 @@ use crate::expression::escape::{flat_col, unescaped_col};
 use crate::sql::dataframe::SqlDataFrame;
 use async_trait::async_trait;
 use datafusion::common::{DFSchema, ScalarValue};
+use datafusion_expr::aggregate_function;
 use datafusion_expr::expr;
-use datafusion_expr::{
-    aggregate_function, BuiltInWindowFunction, WindowFrame, WindowFrameBound, WindowFrameUnits,
-    WindowFunction,
-};
 use std::sync::Arc;
 use vegafusion_core::arrow::datatypes::DataType;
 use vegafusion_core::data::ORDER_COL;

--- a/vegafusion-rt-datafusion/src/transform/aggregate.rs
+++ b/vegafusion-rt-datafusion/src/transform/aggregate.rs
@@ -16,6 +16,7 @@ use datafusion_expr::{
 };
 use std::sync::Arc;
 use vegafusion_core::arrow::datatypes::DataType;
+use vegafusion_core::data::ORDER_COL;
 use vegafusion_core::error::{Result, VegaFusionError};
 use vegafusion_core::expression::escape::unescape_field;
 use vegafusion_core::proto::gen::transforms::{Aggregate, AggregateOp};
@@ -32,34 +33,11 @@ impl TransformTrait for Aggregate {
         let group_exprs: Vec<_> = self.groupby.iter().map(|c| unescaped_col(c)).collect();
         let (mut agg_exprs, projections) = get_agg_and_proj_exprs(self, &dataframe.schema_df())?;
 
-        // Add __row_number column if groupby columns is not empty
-        let dataframe = if !self.groupby.is_empty() {
-            //  Add row_number column that we can sort by
-            let row_number_expr = make_row_number_expr();
-
-            // Add min(__row_number) aggregation that we can sort by later
-            agg_exprs.push(min(flat_col("__row_number")).alias("__min_row_number"));
-
-            dataframe
-                .select(vec![Expr::Wildcard, row_number_expr])
-                .await?
-        } else {
-            dataframe
-        };
+        // Append ordering column to aggregations
+        agg_exprs.push(min(flat_col(ORDER_COL)).alias(ORDER_COL));
 
         // Perform aggregation
-        let mut grouped_dataframe = dataframe.aggregate(group_exprs, agg_exprs).await?;
-
-        // Maybe sort by min row number
-        if !self.groupby.is_empty() {
-            // Sort groups according to the lowest row number of a value in that group
-            let sort_exprs = vec![Expr::Sort(expr::Sort {
-                expr: Box::new(flat_col("__min_row_number")),
-                asc: true,
-                nulls_first: false,
-            })];
-            grouped_dataframe = grouped_dataframe.sort(sort_exprs, None).await?;
-        }
+        let grouped_dataframe = dataframe.aggregate(group_exprs, agg_exprs).await?;
 
         // Make final projection
         let grouped_dataframe = grouped_dataframe.select(projections).await?;
@@ -91,6 +69,9 @@ fn get_agg_and_proj_exprs(tx: &Aggregate, schema: &DFSchema) -> Result<(Vec<Expr
 
     // Initialize vec of final projections with the grouping fields
     let mut projections: Vec<_> = tx.groupby.iter().map(|f| unescaped_col(f)).collect();
+
+    // Prepend ORDER_COL
+    projections.insert(0, flat_col(ORDER_COL));
 
     for (i, (field, op_code)) in tx.fields.iter().zip(tx.ops.iter()).enumerate() {
         let op = AggregateOp::from_i32(*op_code).unwrap();

--- a/vegafusion-rt-datafusion/src/transform/aggregate.rs
+++ b/vegafusion-rt-datafusion/src/transform/aggregate.rs
@@ -46,21 +46,6 @@ impl TransformTrait for Aggregate {
     }
 }
 
-pub fn make_row_number_expr() -> Expr {
-    Expr::WindowFunction(expr::WindowFunction {
-        fun: WindowFunction::BuiltInWindowFunction(BuiltInWindowFunction::RowNumber),
-        args: Vec::new(),
-        partition_by: Vec::new(),
-        order_by: Vec::new(),
-        window_frame: WindowFrame {
-            units: WindowFrameUnits::Rows,
-            start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
-            end_bound: WindowFrameBound::CurrentRow,
-        },
-    })
-    .alias("__row_number")
-}
-
 fn get_agg_and_proj_exprs(tx: &Aggregate, schema: &DFSchema) -> Result<(Vec<Expr>, Vec<Expr>)> {
     // DataFusion does not allow repeated (field, op) combinations in an aggregate expression,
     // so if there are duplicates we need to use a projection after the aggregation to alias

--- a/vegafusion-rt-datafusion/src/transform/collect.rs
+++ b/vegafusion-rt-datafusion/src/transform/collect.rs
@@ -7,9 +7,14 @@ use std::sync::Arc;
 use vegafusion_core::error::{Result, ResultWithContext};
 use vegafusion_core::proto::gen::transforms::{Collect, SortOrder};
 
-use crate::expression::escape::unescaped_col;
+use crate::expression::escape::{flat_col, unescaped_col};
 use crate::sql::dataframe::SqlDataFrame;
 use async_trait::async_trait;
+use datafusion::common::ScalarValue;
+use datafusion_expr::{
+    window_function, BuiltInWindowFunction, WindowFrame, WindowFrameBound, WindowFrameUnits,
+};
+use vegafusion_core::data::ORDER_COL;
 use vegafusion_core::task_graph::task_value::TaskValue;
 
 #[async_trait]
@@ -19,6 +24,7 @@ impl TransformTrait for Collect {
         dataframe: Arc<SqlDataFrame>,
         _config: &CompilationConfig,
     ) -> Result<(Arc<SqlDataFrame>, Vec<TaskValue>)> {
+        // Build vector of sort expressions
         let sort_exprs: Vec<_> = self
             .fields
             .clone()
@@ -33,8 +39,41 @@ impl TransformTrait for Collect {
             })
             .collect();
 
+        // We don't actually sort here, use a row number window function sorted by the sort
+        // criteria. This column becomes the new ORDER_COL, which will be sorted at the end of
+        // the pipeline.
+        let order_col = Expr::WindowFunction(expr::WindowFunction {
+            fun: window_function::WindowFunction::BuiltInWindowFunction(
+                BuiltInWindowFunction::RowNumber,
+            ),
+            args: vec![],
+            partition_by: vec![],
+            order_by: sort_exprs,
+            window_frame: WindowFrame {
+                units: WindowFrameUnits::Rows,
+                start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+                end_bound: WindowFrameBound::CurrentRow,
+            },
+        })
+        .alias(ORDER_COL);
+
+        // Build vector of selections
+        let mut selections = dataframe
+            .schema()
+            .fields
+            .iter()
+            .filter_map(|field| {
+                if field.name() == ORDER_COL {
+                    None
+                } else {
+                    Some(flat_col(field.name()))
+                }
+            })
+            .collect::<Vec<_>>();
+        selections.insert(0, order_col);
+
         let result = dataframe
-            .sort(sort_exprs, None)
+            .select(selections)
             .await
             .with_context(|| "Collect transform failed".to_string())?;
         Ok((result, Default::default()))

--- a/vegafusion-rt-datafusion/src/transform/impute.rs
+++ b/vegafusion-rt-datafusion/src/transform/impute.rs
@@ -213,8 +213,8 @@ async fn single_groupby_sql(
         .collect::<Vec<_>>();
     selections.insert(0, order_col);
 
-    Ok(dataframe
+    dataframe
         .select(selections)
         .await
-        .with_context(|| "Impute transform failed".to_string())?)
+        .with_context(|| "Impute transform failed".to_string())
 }

--- a/vegafusion-rt-datafusion/src/transform/impute.rs
+++ b/vegafusion-rt-datafusion/src/transform/impute.rs
@@ -1,6 +1,5 @@
 use crate::expression::compiler::config::CompilationConfig;
 use crate::expression::escape::{flat_col, unescaped_col};
-use crate::sql::compile::order::ToSqlOrderByExpr;
 use crate::sql::compile::select::ToSqlSelectItem;
 use crate::sql::dataframe::SqlDataFrame;
 use crate::transform::aggregate::make_row_number_expr;
@@ -8,13 +7,17 @@ use crate::transform::TransformTrait;
 use async_trait::async_trait;
 use datafusion::common::ScalarValue;
 use datafusion_expr::expr::Cast;
-use datafusion_expr::{expr, lit, when, Expr};
+use datafusion_expr::{
+    expr, lit, when, window_function, BuiltInWindowFunction, Expr, WindowFrame, WindowFrameBound,
+    WindowFrameUnits,
+};
 use itertools::Itertools;
 use sqlgen::dialect::DialectDisplay;
 use std::sync::Arc;
 use vegafusion_core::arrow::datatypes::DataType;
 use vegafusion_core::data::scalar::ScalarValueHelpers;
-use vegafusion_core::error::{Result, VegaFusionError};
+use vegafusion_core::data::ORDER_COL;
+use vegafusion_core::error::{Result, ResultWithContext, VegaFusionError};
 use vegafusion_core::proto::gen::transforms::Impute;
 use vegafusion_core::task_graph::task_value::TaskValue;
 
@@ -116,14 +119,6 @@ async fn single_groupby_sql(
     let row_number_expr = make_row_number_expr();
     let row_number_expr_str = row_number_expr.to_sql_select()?.sql(dataframe.dialect())?;
 
-    // Build order by
-    let order_by_expr = Expr::Sort(expr::Sort {
-        expr: Box::new(flat_col("__row_number")),
-        asc: true,
-        nulls_first: false,
-    });
-    let order_by_expr_str = order_by_expr.to_sql_order()?.sql(dataframe.dialect())?;
-
     // Build final selection
     // Finally, select all of the original DataFrame columns, filling in missing values
     // of the `field` columns
@@ -167,15 +162,53 @@ async fn single_groupby_sql(
     let dataframe = dataframe.chain_query_str(&format!(
         "SELECT {select_column_csv} from (SELECT DISTINCT {key} from {parent} WHERE {key} IS NOT NULL) AS _key \
          CROSS JOIN (SELECT DISTINCT {group} from {parent} WHERE {group} IS NOT NULL) AS _group  \
-         LEFT OUTER JOIN (SELECT *, {row_number_expr_str} from {parent}) AS _inner USING ({key}, {group}) \
-         ORDER BY {order_by_expr_str}",
+         LEFT OUTER JOIN (SELECT *, {row_number_expr_str} from {parent}) AS _inner USING ({key}, {group})",
         select_column_csv = select_column_csv,
         key = key_col_str,
         group = group_col_str,
         row_number_expr_str = row_number_expr_str,
-        order_by_expr_str = order_by_expr_str,
         parent = dataframe.parent_name(),
     )).await?;
 
-    Ok(dataframe)
+    // Override ordering column since null values may have been introduced in the query above.
+    // Match input ordering with imputed rows (those will null ordering column) pushed
+    // to the end.
+    let order_col = Expr::WindowFunction(expr::WindowFunction {
+        fun: window_function::WindowFunction::BuiltInWindowFunction(
+            BuiltInWindowFunction::RowNumber,
+        ),
+        args: vec![],
+        partition_by: vec![],
+        order_by: vec![Expr::Sort(expr::Sort {
+            expr: Box::new(flat_col(ORDER_COL)),
+            asc: true,
+            nulls_first: false,
+        })],
+        window_frame: WindowFrame {
+            units: WindowFrameUnits::Rows,
+            start_bound: WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+            end_bound: WindowFrameBound::CurrentRow,
+        },
+    })
+    .alias(ORDER_COL);
+
+    // Build vector of selections
+    let mut selections = dataframe
+        .schema()
+        .fields
+        .iter()
+        .filter_map(|field| {
+            if field.name() == ORDER_COL {
+                None
+            } else {
+                Some(flat_col(field.name()))
+            }
+        })
+        .collect::<Vec<_>>();
+    selections.insert(0, order_col);
+
+    Ok(dataframe
+        .select(selections)
+        .await
+        .with_context(|| "Impute transform failed".to_string())?)
 }

--- a/vegafusion-rt-datafusion/src/transform/impute.rs
+++ b/vegafusion-rt-datafusion/src/transform/impute.rs
@@ -163,7 +163,8 @@ async fn single_groupby_sql(
     let dataframe = dataframe.chain_query_str(&format!(
         "SELECT {select_column_csv} from (SELECT DISTINCT {key} from {parent} WHERE {key} IS NOT NULL) AS _key \
          CROSS JOIN (SELECT DISTINCT {group} from {parent} WHERE {group} IS NOT NULL) AS _group  \
-         LEFT OUTER JOIN (SELECT * from {parent}) AS _inner USING ({key}, {group})",
+         LEFT OUTER JOIN {parent} \
+         USING ({key}, {group})",
         select_column_csv = select_column_csv,
         key = key_col_str,
         group = group_col_str,

--- a/vegafusion-rt-datafusion/src/transform/impute.rs
+++ b/vegafusion-rt-datafusion/src/transform/impute.rs
@@ -29,13 +29,19 @@ impl TransformTrait for Impute {
         _config: &CompilationConfig,
     ) -> Result<(Arc<SqlDataFrame>, Vec<TaskValue>)> {
         // Create ScalarValue used to fill in null values
-        let json_value: serde_json::Value =
-            serde_json::from_str(self.value_json.as_ref().unwrap())?;
+        let json_value: serde_json::Value = serde_json::from_str(
+            &self
+                .value_json
+                .clone()
+                .unwrap_or_else(|| "null".to_string()),
+        )?;
 
         // JSON numbers are always interpreted as floats, but if the value is an integer we'd
         // like the fill value to be an integer as well to avoid converting an integer input
         // column to floats
-        let value = if json_value.is_i64() {
+        let value = if json_value.is_null() {
+            ScalarValue::Float64(None)
+        } else if json_value.is_i64() {
             ScalarValue::from(json_value.as_i64().unwrap())
         } else if json_value.is_f64() && json_value.as_f64().unwrap().fract() == 0.0 {
             ScalarValue::from(json_value.as_f64().unwrap() as i64)

--- a/vegafusion-rt-datafusion/src/transform/pipeline.rs
+++ b/vegafusion-rt-datafusion/src/transform/pipeline.rs
@@ -101,14 +101,7 @@ impl TransformPipelineUtils for TransformPipeline {
             .await?;
 
         // Remove ordering column
-        let selection = result_sql_df.schema().fields.iter().filter_map(|field| {
-            if field.name() == ORDER_COL {
-                None
-            } else {
-                Some(flat_col(field.name()))
-            }
-        }).collect::<Vec<_>>();
-        result_sql_df = result_sql_df.select(selection).await?;
+        result_sql_df = remove_order_col(result_sql_df).await?;
 
         let table = result_sql_df.collect().await?;
 
@@ -120,4 +113,20 @@ impl TransformPipelineUtils for TransformPipeline {
 
         Ok((table, signals_values))
     }
+}
+
+pub async fn remove_order_col(result_sql_df: Arc<SqlDataFrame>) -> Result<Arc<SqlDataFrame>> {
+    let selection = result_sql_df
+        .schema()
+        .fields
+        .iter()
+        .filter_map(|field| {
+            if field.name() == ORDER_COL {
+                None
+            } else {
+                Some(flat_col(field.name()))
+            }
+        })
+        .collect::<Vec<_>>();
+    result_sql_df.select(selection).await
 }

--- a/vegafusion-rt-datafusion/src/transform/project.rs
+++ b/vegafusion-rt-datafusion/src/transform/project.rs
@@ -10,6 +10,7 @@ use vegafusion_core::proto::gen::transforms::Project;
 use crate::expression::escape::flat_col;
 use crate::sql::dataframe::SqlDataFrame;
 use async_trait::async_trait;
+use vegafusion_core::data::ORDER_COL;
 use vegafusion_core::expression::escape::unescape_field;
 use vegafusion_core::task_graph::task_value::TaskValue;
 
@@ -30,7 +31,7 @@ impl TransformTrait for Project {
 
         // Keep all of the project columns that are present in the dataframe.
         // Skip projection fields that are not found
-        let select_fields: Vec<_> = self
+        let mut select_fields: Vec<_> = self
             .fields
             .iter()
             .filter_map(|field| {
@@ -42,6 +43,9 @@ impl TransformTrait for Project {
                 }
             })
             .collect();
+
+        // Always keep ordering column
+        select_fields.insert(0, ORDER_COL.to_string());
 
         let select_col_exprs: Vec<_> = select_fields.iter().map(|f| flat_col(f)).collect();
         let result = dataframe.select(select_col_exprs).await?;

--- a/vegafusion-rt-datafusion/src/transform/window.rs
+++ b/vegafusion-rt-datafusion/src/transform/window.rs
@@ -48,12 +48,14 @@ impl TransformTrait for Window {
             .map(|f| flat_col(f.field().name()))
             .collect();
 
-        // Order by input row ordering last
-        order_by.push(Expr::Sort(expr::Sort {
-            expr: Box::new(flat_col(ORDER_COL)),
-            asc: true,
-            nulls_first: true,
-        }));
+        if order_by.is_empty() {
+            // Order by input row if no ordering specified
+            order_by.push(Expr::Sort(expr::Sort {
+                expr: Box::new(flat_col(ORDER_COL)),
+                asc: true,
+                nulls_first: true,
+            }));
+        };
 
         let partition_by: Vec<_> = self
             .groupby

--- a/vegafusion-rt-datafusion/tests/specs/custom/area_streamgraph.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/area_streamgraph.comm_plan.json
@@ -1,0 +1,4 @@
+{
+  "server_to_client": [],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/area_streamgraph.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/area_streamgraph.comm_plan.json
@@ -1,4 +1,15 @@
 {
-  "server_to_client": [],
+  "server_to_client": [
+    {
+      "name": "source_0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "source_0_color_domain_series",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
   "client_to_server": []
 }

--- a/vegafusion-rt-datafusion/tests/specs/custom/area_streamgraph.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/area_streamgraph.vg.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 400,
+  "height": 300,
+  "style": "cell",
+  "data": [
+    {
+      "name": "source_0",
+      "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/unemployment-across-industries.json",
+      "format": {
+        "type": "json",
+        "parse": {
+          "date": "date"
+        }
+      },
+      "transform": [
+        {
+          "field": "date",
+          "type": "timeunit",
+          "units": [
+            "year",
+            "month"
+          ],
+          "as": [
+            "yearmonth_date",
+            "yearmonth_date_end"
+          ]
+        },
+        {
+          "type": "aggregate",
+          "groupby": [
+            "series",
+            "yearmonth_date"
+          ],
+          "ops": [
+            "sum"
+          ],
+          "fields": [
+            "count"
+          ],
+          "as": [
+            "sum_count"
+          ]
+        },
+        {
+          "type": "impute",
+          "field": "sum_count",
+          "groupby": [
+            "series"
+          ],
+          "key": "yearmonth_date",
+          "method": "value",
+          "value": 0
+        },
+        {
+          "type": "stack",
+          "groupby": [
+            "yearmonth_date"
+          ],
+          "field": "sum_count",
+          "sort": {
+            "field": [
+              "series"
+            ],
+            "order": [
+              "descending"
+            ]
+          },
+          "as": [
+            "sum_count_start",
+            "sum_count_end"
+          ],
+          "offset": "center"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "pathgroup",
+      "type": "group",
+      "from": {
+        "facet": {
+          "name": "faceted_path_main",
+          "data": "source_0",
+          "groupby": [
+            "series"
+          ]
+        }
+      },
+      "encode": {
+        "update": {
+          "width": {
+            "field": {
+              "group": "width"
+            }
+          },
+          "height": {
+            "field": {
+              "group": "height"
+            }
+          }
+        }
+      },
+      "marks": [
+        {
+          "name": "marks",
+          "type": "area",
+          "style": [
+            "area"
+          ],
+          "sort": {
+            "field": "datum[\"yearmonth_date\"]"
+          },
+          "from": {
+            "data": "faceted_path_main"
+          },
+          "encode": {
+            "update": {
+              "orient": {
+                "value": "vertical"
+              },
+              "fill": {
+                "scale": "color",
+                "field": "series"
+              },
+              "description": {
+                "signal": "\"series: \" + (isValid(datum[\"series\"]) ? datum[\"series\"] : \"\"+datum[\"series\"]) + \"; date (year-month): \" + (timeFormat(datum[\"yearmonth_date\"], '%Y')) + \"; Sum of count: \" + (format(datum[\"sum_count\"], \"\"))"
+              },
+              "x": {
+                "scale": "x",
+                "field": "yearmonth_date"
+              },
+              "y": {
+                "scale": "y",
+                "field": "sum_count_end"
+              },
+              "y2": {
+                "scale": "y",
+                "field": "sum_count_start"
+              },
+              "defined": {
+                "signal": "isValid(datum[\"yearmonth_date\"]) && isFinite(+datum[\"yearmonth_date\"]) && isValid(datum[\"sum_count\"]) && isFinite(+datum[\"sum_count\"])"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "time",
+      "domain": {
+        "data": "source_0",
+        "field": "yearmonth_date"
+      },
+      "range": [
+        0,
+        {
+          "signal": "width"
+        }
+      ]
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "data": "source_0",
+        "fields": [
+          "sum_count_start",
+          "sum_count_end"
+        ]
+      },
+      "range": [
+        {
+          "signal": "height"
+        },
+        0
+      ],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {
+        "data": "source_0",
+        "field": "series",
+        "sort": true
+      },
+      "range": {
+        "scheme": "category20b"
+      }
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "gridScale": "y",
+      "grid": true,
+      "tickCount": {
+        "signal": "ceil(width/40)"
+      },
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "date (year-month)",
+      "domain": false,
+      "format": "%Y",
+      "tickSize": 0,
+      "labelFlush": true,
+      "labelOverlap": true,
+      "tickCount": {
+        "signal": "ceil(width/40)"
+      },
+      "zindex": 0
+    }
+  ],
+  "legends": [
+    {
+      "fill": "color",
+      "symbolType": "circle",
+      "title": "series"
+    }
+  ]
+}

--- a/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_order_custom.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/vegalite/stacked_bar_h_order_custom.vg.json
@@ -12,7 +12,7 @@
       "transform": [
         {
           "type": "formula",
-          "expr": "if(datum.site === 'University Farm', '0', if(datum.site === 'Grand Rapids', '1', datum.site))",
+          "expr": "if(datum.site === 'University Farm', 0, if(datum.site === 'Grand Rapids', 1, 2))",
           "as": "siteOrder"
         },
         {

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -129,7 +129,8 @@ mod test_custom_specs {
         case("custom/datetime_scatter", 0.001, false),
         case("custom/stack_divide_by_zero_error", 0.001, false),
         case("custom/casestudy-us_population_pyramid_over_time", 0.001, true),
-        case("custom/sin_cos", 0.001, true)
+        case("custom/sin_cos", 0.001, true),
+        case("custom/area_streamgraph", 0.001, true)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {}", spec_name);

--- a/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
@@ -54,7 +54,7 @@ mod test_aggregate_single {
             eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
         } else {
             let eq_config = TablesEqualConfig {
-                row_order: false,
+                row_order: true,
                 ..Default::default()
             };
 
@@ -115,7 +115,7 @@ mod test_aggregate_multi {
         } else {
             // Order of grouped rows is not defined, so set row_order to false
             let eq_config = TablesEqualConfig {
-                row_order: false,
+                row_order: true,
                 ..Default::default()
             };
 
@@ -175,7 +175,7 @@ fn test_bin_aggregate() {
 
     let comp_config = Default::default();
     let eq_config = TablesEqualConfig {
-        row_order: false,
+        row_order: true,
         ..Default::default()
     };
 
@@ -218,7 +218,7 @@ fn test_aggregate_overwrite() {
 
     // Order of grouped rows is not defined, so set row_order to false
     let eq_config = TablesEqualConfig {
-        row_order: false,
+        row_order: true,
         ..Default::default()
     };
 
@@ -279,7 +279,7 @@ mod test_aggregate_with_nulls {
             eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
         } else {
             let eq_config = TablesEqualConfig {
-                row_order: false,
+                row_order: true,
                 ..Default::default()
             };
 

--- a/vegafusion-rt-datafusion/tests/test_transform_identifier.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_identifier.rs
@@ -9,7 +9,7 @@ use vegafusion_core::spec::transform::identifier::IdentifierTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
 
 #[test]
-fn test_formula_valid() {
+fn test_identifier() {
     let dataset = vega_json_dataset("penguins");
     let tx_spec = IdentifierTransformSpec {
         as_: "id".to_string(),

--- a/vegafusion-rt-datafusion/tests/test_transform_impute.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_impute.rs
@@ -90,4 +90,50 @@ mod test_impute {
             &eq_config,
         );
     }
+
+    #[test]
+    fn test_one_groupby_window_frame() {
+        let dataset = simple_dataset();
+
+        let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!(
+            [
+                {"type": "formula", "expr": "toNumber(datum[\"a\"])", "as": "a"},
+                {
+                  "type": "impute",
+                  "field": "b",
+                  "key": "a",
+                  "method": "value",
+                  "groupby": ["c"],
+                  "value": null
+                },
+                {
+                  "type": "window",
+                  "as": ["imputed_b_value"],
+                  "ops": ["mean"],
+                  "fields": ["b"],
+                  "frame": [-2, 2],
+                  "ignorePeers": false,
+                  "groupby": ["c"]
+                },
+                {
+                  "type": "formula",
+                  "expr": "datum.b === null ? datum.imputed_b_value : datum.b",
+                  "as": "b"
+                }
+            ]
+        )).unwrap();
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
 }

--- a/vegafusion-rt-datafusion/tests/test_transform_impute.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_impute.rs
@@ -121,7 +121,8 @@ mod test_impute {
                   "as": "b"
                 }
             ]
-        )).unwrap();
+        ))
+        .unwrap();
 
         let comp_config = Default::default();
         let eq_config = TablesEqualConfig {

--- a/vegafusion-rt-datafusion/tests/test_transform_window.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_window.rs
@@ -84,7 +84,7 @@ mod test_window_single {
         let comp_config = Default::default();
 
         let eq_config = TablesEqualConfig {
-            row_order: false,
+            row_order: true,
             ..Default::default()
         };
 

--- a/vegafusion-rt-datafusion/tests/util/check.rs
+++ b/vegafusion-rt-datafusion/tests/util/check.rs
@@ -114,6 +114,8 @@ pub fn eval_vegafusion_transforms(
     transform_specs: &[TransformSpec],
     compilation_config: &CompilationConfig,
 ) -> (VegaFusionTable, Vec<ScalarValue>) {
+    // add ordering column
+    let data = data.clone().with_ordering().unwrap();
     let pipeline = TransformPipeline::try_from(transform_specs).unwrap();
     let sql_df = (*TOKIO_RUNTIME).block_on(data.to_sql_dataframe()).unwrap();
 


### PR DESCRIPTION
## Background
Unlike SQL, The row order of the result of Vega transforms is deterministic based on the transform specification and the order of the input rows.  For example, the rows that result from the `aggregate` transform are ordered according to first appearance of a row in each group.

Prior to this PR, we attempted to match Vega's ordering by having individual transforms use a ROW_NUMBER() window function on their input, and the resort their output based on this ROW_NUMBER().  This worked most of the time, but it was a bit of a hack since creating a new column using a ROW_NUMBER window function, and no ordering specification, isn't guaranteed to be sorted with the input rows.

Here is one example where this approach goes wrong: https://github.com/apache/arrow-datafusion/issues/4673.

## Overview

This PR introduces an explicit ordering column named `_vf_order`. This column is added to every input dataset, and every transforms inputs and outputs the column.  The final dataset is sorted by `_vf_order` after all of the transforms in the pipeline have been applied.