### PR TITLE
Support impute with multiple groupby fields and match Vega's output ordering

### DIFF
--- a/python/vegafusion/tests/test_transformed_data.py
+++ b/python/vegafusion/tests/test_transformed_data.py
@@ -73,6 +73,7 @@ altair_mocks_dir = here / "altair_mocks"
         ("other/multiple_marks", 560, ["symbol", "date", "price"]),
         ("other/stem_and_leaf", 100, ["samples", "stem", "leaf", "position"]),
         ("other/wilkinson_dot_plot", 21, ["data", "id"]),
+        ("other/ridgeline_plot", 108, ["Month", "mean_temp", "value"]),
         ("scatter/binned", 64, ["__count", "bin_maxbins_10_Rotten_Tomatoes_Rating_end"]),
         ("scatter/bubble_plot", 392, ["Name", "Cylinders", "Origin"]),
         ("scatter/connected", 55, ["side", "year", "miles", "gas"]),

--- a/python/vegafusion/vegafusion/evaluation.py
+++ b/python/vegafusion/vegafusion/evaluation.py
@@ -1,7 +1,7 @@
 import json
 
 from altair import data_transformers
-from altair.vegalite.v4.api import Chart
+from altair.vegalite.v4.api import Chart, FacetChart
 from altair.utils.schemapi import Undefined
 
 MAGIC_MARK_NAME = "_vf_mark"
@@ -19,10 +19,10 @@ def transformed_data(chart: Chart, row_limit=None):
 
     from . import runtime, get_local_tz, get_inline_datasets_for_spec, vegalite_compilers
 
-    if not isinstance(chart, Chart):
+    if not isinstance(chart, (Chart, FacetChart)):
         raise ValueError(
             "transformed_data accepts an instance of "
-            "altair.vegalite.v4.api.Chart\n"
+            "Chart or FacetChart\n"
             f"Received value of type: {type(chart)}"
         )
 
@@ -31,9 +31,10 @@ def transformed_data(chart: Chart, row_limit=None):
     chart = chart.copy(deep=False)
     chart.name = MAGIC_MARK_NAME
 
-    # Add dummy mark if None specified
-    if chart.mark == Undefined:
-        chart = chart.mark_point()
+    if isinstance(chart, Chart):
+        # Add dummy mark if None specified
+        if chart.mark == Undefined:
+            chart = chart.mark_point()
 
     with data_transformers.enable("vegafusion-inline"):
         vega_spec = vegalite_compilers.get()(chart.to_json(validate=False))

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -3,7 +3,6 @@ use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::Field;
 use crate::task_graph::graph::ScopedVariable;
 use crate::task_graph::scope::TaskScope;
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -56,18 +55,10 @@ pub enum ImputeMethodSpec {
 
 impl TransformSpecTrait for ImputeTransformSpec {
     fn supported(&self) -> bool {
-        let num_unique_groupby = self
-            .groupby
-            .clone()
-            .unwrap_or_default()
-            .iter()
-            .unique()
-            .count();
         self.field.as_().is_none()
             && self.key.as_().is_none()
             && self.keyvals.is_none()
             && self.method() == ImputeMethodSpec::Value
-            && num_unique_groupby <= 1
     }
 
     fn transform_columns(

--- a/vegafusion-rt-datafusion/tests/specs/custom/ridgeline.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/ridgeline.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "row_domain",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_x_domain_bin_min",
       "scope": []
     }
   ],

--- a/vegafusion-rt-datafusion/tests/test_transform_impute.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_impute.rs
@@ -18,12 +18,12 @@ mod test_impute {
         VegaFusionTable::from_json(
             &json!([
                 {"a": 0, "b": 28, "c": 0, "d": -1},
-                {"a": 0, "b": 91, "c": 1, "d": -2},
-                {"a": 1, "b": 43, "c": 0, "d": -3},
-                {"a": 1, "b": 55, "c": 1, "d": -4},
-                {"a": 3, "b": 19, "c": 0, "d": -7},
-                {"a": 2, "b": 81, "c": 0, "d": -5},
-                {"a": 2, "b": 53, "c": 1, "d": -6},
+                {"a": 0, "b": 91, "c": 1, "d": -1},
+                {"a": 1, "b": 43, "c": 0, "d": -2},
+                {"a": 1, "b": 55, "c": 1, "d": -2},
+                {"a": 3, "b": 19, "c": 0, "d": -3},
+                {"a": 2, "b": 81, "c": 0, "d": -3},
+                {"a": 2, "b": 53, "c": 1, "d": -4},
 
             ]),
             1024,
@@ -46,6 +46,35 @@ mod test_impute {
         };
 
         let transform_specs = vec![TransformSpec::Impute(impute_spec)];
+
+        let comp_config = Default::default();
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+
+    #[test]
+    fn test_two_groupby() {
+        let dataset = simple_dataset();
+
+        let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!([
+            {
+                "type": "impute",
+                "field": "a",
+                "key": "b",
+                "groupby": ["c", "d"],
+                "value": -1
+            },
+        ]))
+        .unwrap();
 
         let comp_config = Default::default();
         let eq_config = TablesEqualConfig {

--- a/vegafusion-rt-datafusion/tests/util/equality.rs
+++ b/vegafusion-rt-datafusion/tests/util/equality.rs
@@ -17,6 +17,8 @@ use vegafusion_rt_datafusion::expression::escape::flat_col;
 use vegafusion_rt_datafusion::tokio_runtime::TOKIO_RUNTIME;
 use vegafusion_rt_datafusion::transform::utils::DataFrameUtils;
 
+const DROP_COLS: &[&str] = &[ORDER_COL, "_impute"];
+
 #[derive(Debug, Clone)]
 pub struct TablesEqualConfig {
     pub row_order: bool,
@@ -43,7 +45,7 @@ pub fn assert_tables_equal(
         .fields()
         .iter()
         .filter_map(|f| {
-            if f.name() == ORDER_COL {
+            if DROP_COLS.contains(&f.name().as_str()) {
                 None
             } else {
                 Some(f.name().clone())
@@ -55,7 +57,7 @@ pub fn assert_tables_equal(
         .fields()
         .iter()
         .filter_map(|f| {
-            if f.name() == ORDER_COL {
+            if DROP_COLS.contains(&f.name().as_str()) {
                 None
             } else {
                 Some(f.name().clone())
@@ -161,11 +163,11 @@ fn assert_scalars_almost_equals(
             let lhs_map: HashMap<_, _> = lhs_fields
                 .iter()
                 .zip(lhs_vals.iter())
-                .filter_map(|(field, val)| {
-                    if field.name() == ORDER_COL {
+                .filter_map(|(f, val)| {
+                    if DROP_COLS.contains(&f.name().as_str()) {
                         None
                     } else {
-                        Some((field.name().clone(), val.clone()))
+                        Some((f.name().clone(), val.clone()))
                     }
                 })
                 .collect();
@@ -173,11 +175,11 @@ fn assert_scalars_almost_equals(
             let rhs_map: HashMap<_, _> = rhs_fields
                 .iter()
                 .zip(rhs_vals.iter())
-                .filter_map(|(field, val)| {
-                    if field.name() == ORDER_COL {
+                .filter_map(|(f, val)| {
+                    if DROP_COLS.contains(&f.name().as_str()) {
                         None
                     } else {
-                        Some((field.name().clone(), val.clone()))
+                        Some((f.name().clone(), val.clone()))
                     }
                 })
                 .collect();


### PR DESCRIPTION
This PR adds support for the `impute` transform with more than one `groupby` field.  It also updates the `transfored_data` Python function to handle `FacetChart` instances